### PR TITLE
Add `get-changes.sh` script to see exactly what changed between release for a specific target

### DIFF
--- a/scripts/get-changes.sh
+++ b/scripts/get-changes.sh
@@ -28,7 +28,7 @@ temp_commits=$(mktemp)
 git diff --name-only $OLD_COMMIT | xargs -I {} realpath "{}" | sort > "$temp_git"
 
 # Get Bazel target dependencies and write directly to temp file
-bazel query --output=location "filter('^//', kind('source file', deps(//ic-os/guestos/envs/prod:prod)))" | sed 's/:[0-9]*:[0-9]*: .*$//' | sort > "$temp_bazel"
+bazel query --output=location "filter('^//', kind('source file', deps(//ic-os/guestos/envs/prod:update-img.tar.gz)))" | sed 's/:[0-9]*:[0-9]*: .*$//' | sort > "$temp_bazel"
 
 # Use comm to find common files and save to a temporary file
 comm -12 "$temp_git" "$temp_bazel" > "$temp_common"

--- a/scripts/get-changes.sh
+++ b/scripts/get-changes.sh
@@ -7,7 +7,7 @@ if [ "$#" -ne 2 ]; then
     exit 1
 fi
 
-REPO_URL="https://github.com/dfinity/ic.git"
+REPO_URL="https://github.com/dfinity/ic"
 OLD_COMMIT="$1"
 NEW_COMMIT="$2"
 

--- a/scripts/get-changes.sh
+++ b/scripts/get-changes.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -eEuo pipefail 
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <old_commit> <new_commit>"
+    exit 1
+fi
+
+REPO_URL="https://github.com/dfinity/ic.git"
+OLD_COMMIT="$1"
+NEW_COMMIT="$2"
+
+
+TEMP_DIR=$(mktemp -d)
+echo "Working in temporary directory: $TEMP_DIR"
+
+git clone "$REPO_URL" "$TEMP_DIR/ic"
+pushd "$TEMP_DIR/ic" > /dev/null
+git checkout $NEW_COMMIT
+
+temp_git=$(mktemp)
+temp_bazel=$(mktemp)
+temp_common=$(mktemp)
+temp_commits=$(mktemp)
+
+# Get Git changed files and write directly to temp file
+git diff --name-only $OLD_COMMIT | xargs -I {} realpath "{}" | sort > "$temp_git"
+
+# Get Bazel target dependencies and write directly to temp file
+bazel query --output=location "filter('^//', kind('source file', deps(//ic-os/guestos/envs/prod:prod)))" | sed 's/:[0-9]*:[0-9]*: .*$//' | sort > "$temp_bazel"
+
+# Use comm to find common files and save to a temporary file
+comm -12 "$temp_git" "$temp_bazel" > "$temp_common"
+
+echo "Files that have changed and are dependencies of the Bazel target:"
+cat "$temp_common"
+echo
+
+echo "Collecting unique commits..."
+while IFS= read -r file; do
+    git log --oneline $OLD_COMMIT..$NEW_COMMIT -- "$file" >> "$temp_commits"
+done < "$temp_common"
+
+echo "Unique commits that modified the relevant files, with PR links:"
+sort -u "$temp_commits" | while read -r line; do
+    commit_hash=$(echo "$line" | cut -d' ' -f1)
+    commit_msg=$(echo "$line" | cut -d' ' -f2-)
+    pr_number=$(echo "$commit_msg" | grep -oP '#\K\d+')
+    if [ -n "$pr_number" ]; then
+        pr_url="$REPO_URL/pull/$pr_number"
+        echo "$line"
+        echo "PR: $pr_url"
+        echo
+    else
+        echo "$line"
+        echo "No PR number found in commit message"
+        echo
+    fi
+done
+
+# Clean up temporary files
+rm "$temp_git" "$temp_bazel" "$temp_common" "$temp_commits"


### PR DESCRIPTION
Output of the script that prints which PRs have changed dependencies of the GuestOS image between commit [2bdfdc54ccc7ef27dd7b4f37aaea172198dce6ab](https://github.com/dfinity/ic/commit/2bdfdc54ccc7ef27dd7b4f37aaea172198dce6ab)  and [3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d](https://github.com/dfinity/ic/commit/3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d)

```bash
enzo@merlaux ~/c/WaterNeuron (add-changes) [1]> ./scripts/get-changes.sh 2bdfdc54ccc7ef27dd7b4f37aaea172198dce6ab 3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d
Working in temporary directory: /tmp/tmp.meVJxO5BDk
Cloning into '/tmp/tmp.meVJxO5BDk/ic'...
remote: Enumerating objects: 309559, done.
remote: Counting objects: 100% (4709/4709), done.
remote: Compressing objects: 100% (1598/1598), done.
remote: Total 309559 (delta 3237), reused 4243 (delta 2953), pack-reused 304850
Receiving objects: 100% (309559/309559), 235.75 MiB | 25.04 MiB/s, done.
Resolving deltas: 100% (217241/217241), done.
Note: switching to '3d0b3f10417fc6708e8b5d844a0bac5e86f3e17d'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at 3d0b3f1041 fix(nns): Fixed a bug where known neuron is not seen as public. (#699)
Starting local Bazel server and connecting to it...
Files that have changed and are dependencies of the Bazel target:
/tmp/tmp.meVJxO5BDk/ic/ic-os/guestos/context/docker-base.dev
/tmp/tmp.meVJxO5BDk/ic/ic-os/guestos/context/docker-base.prod
/tmp/tmp.meVJxO5BDk/ic/rs/artifact_pool/src/idkg_pool.rs
/tmp/tmp.meVJxO5BDk/ic/rs/artifact_pool/src/lmdb_pool.rs
/tmp/tmp.meVJxO5BDk/ic/rs/bitcoin/consensus/src/payload_builder/proptests.rs
/tmp/tmp.meVJxO5BDk/ic/rs/boundary_node/ic_boundary/src/acme.rs
/tmp/tmp.meVJxO5BDk/ic/rs/boundary_node/ic_boundary/src/core.rs
/tmp/tmp.meVJxO5BDk/ic/rs/boundary_node/ic_boundary/src/main.rs
/tmp/tmp.meVJxO5BDk/ic/rs/canister_sandbox/src/replica_controller/sandboxed_execution_controller.rs
/tmp/tmp.meVJxO5BDk/ic/rs/config/src/subnet_config.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/src/certification/certifier.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/src/consensus.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/src/consensus/block_maker.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/src/consensus/catchup_package_maker.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/src/consensus/notary.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/src/consensus/purger.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/src/consensus/random_tape_maker.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/src/consensus/validator.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/src/dkg/payload_builder.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/src/dkg/payload_validator.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/src/idkg/payload_builder/pre_signatures.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/src/idkg/test_utils.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/src/idkg/utils.rs
/tmp/tmp.meVJxO5BDk/ic/rs/consensus/utils/src/lib.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/ecdsa_secp256k1/src/lib.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/internal/crypto_lib/multi_sig/bls12_381/src/types/generic_traits.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/internal/crypto_lib/threshold_sig/bls12_381/src/types/generic_traits.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/internal/crypto_lib/threshold_sig/tecdsa/src/lib.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/internal/crypto_lib/threshold_sig/tecdsa/src/utils/group.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/internal/crypto_service_provider/src/api/sign.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/internal/crypto_service_provider/src/api/threshold.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/internal/crypto_service_provider/src/public_key_store/mod.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/internal/crypto_service_provider/src/signer/mod.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/internal/crypto_service_provider/src/threshold/ni_dkg/mod.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/internal/crypto_service_provider/src/threshold/tests.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/internal/crypto_service_provider/src/vault/api.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/internal/crypto_service_provider/src/vault/test_utils/threshold_sig.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/internal/logmon/src/metrics.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/node_key_generation/src/lib.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/src/sign/threshold_sig.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/src/sign/threshold_sig/store.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/tree_hash/src/lib.rs
/tmp/tmp.meVJxO5BDk/ic/rs/crypto/utils/threshold_sig_der/src/conversions.rs
/tmp/tmp.meVJxO5BDk/ic/rs/cycles_account_manager/src/lib.rs
/tmp/tmp.meVJxO5BDk/ic/rs/embedders/src/wasm_utils/validation.rs
/tmp/tmp.meVJxO5BDk/ic/rs/embedders/src/wasmtime_embedder.rs
/tmp/tmp.meVJxO5BDk/ic/rs/embedders/src/wasmtime_embedder/system_api.rs
/tmp/tmp.meVJxO5BDk/ic/rs/execution_environment/src/canister_manager.rs
/tmp/tmp.meVJxO5BDk/ic/rs/execution_environment/src/canister_settings.rs
/tmp/tmp.meVJxO5BDk/ic/rs/execution_environment/src/execution_environment.rs
/tmp/tmp.meVJxO5BDk/ic/rs/execution_environment/src/execution_environment/tests.rs
/tmp/tmp.meVJxO5BDk/ic/rs/execution_environment/src/execution_environment/tests/canister_snapshots.rs
/tmp/tmp.meVJxO5BDk/ic/rs/execution_environment/src/metrics.rs
/tmp/tmp.meVJxO5BDk/ic/rs/execution_environment/src/query_handler/query_context.rs
/tmp/tmp.meVJxO5BDk/ic/rs/execution_environment/src/scheduler.rs
/tmp/tmp.meVJxO5BDk/ic/rs/https_outcalls/consensus/src/payload_builder/utils.rs
/tmp/tmp.meVJxO5BDk/ic/rs/ic_os/network/src/mac_address.rs
/tmp/tmp.meVJxO5BDk/ic/rs/ingress_manager/src/lib.rs
/tmp/tmp.meVJxO5BDk/ic/rs/interfaces/src/crypto/keygen.rs
/tmp/tmp.meVJxO5BDk/ic/rs/interfaces/src/crypto/sign/canister_threshold_sig.rs
/tmp/tmp.meVJxO5BDk/ic/rs/interfaces/src/execution_environment.rs
/tmp/tmp.meVJxO5BDk/ic/rs/interfaces/src/p2p/consensus.rs
/tmp/tmp.meVJxO5BDk/ic/rs/memory_tracker/src/lib.rs
/tmp/tmp.meVJxO5BDk/ic/rs/nervous_system/common/build_metadata/src/lib.rs
/tmp/tmp.meVJxO5BDk/ic/rs/nervous_system/root/src/change_canister.rs
/tmp/tmp.meVJxO5BDk/ic/rs/nns/governance/api/src/ic_nns_governance.pb.v1.rs
/tmp/tmp.meVJxO5BDk/ic/rs/orchestrator/src/firewall.rs
/tmp/tmp.meVJxO5BDk/ic/rs/orchestrator/src/lib.rs
/tmp/tmp.meVJxO5BDk/ic/rs/orchestrator/src/orchestrator.rs
/tmp/tmp.meVJxO5BDk/ic/rs/registry/canister/src/invariants/endpoint.rs
/tmp/tmp.meVJxO5BDk/ic/rs/registry/helpers/src/subnet.rs
/tmp/tmp.meVJxO5BDk/ic/rs/replay/src/backup.rs
/tmp/tmp.meVJxO5BDk/ic/rs/replicated_state/src/canister_snapshots.rs
/tmp/tmp.meVJxO5BDk/ic/rs/replicated_state/src/canister_state.rs
/tmp/tmp.meVJxO5BDk/ic/rs/replicated_state/src/canister_state/execution_state.rs
/tmp/tmp.meVJxO5BDk/ic/rs/replicated_state/src/lib.rs
/tmp/tmp.meVJxO5BDk/ic/rs/replicated_state/src/page_map/page_allocator/mmap.rs
/tmp/tmp.meVJxO5BDk/ic/rs/replicated_state/src/page_map/storage.rs
/tmp/tmp.meVJxO5BDk/ic/rs/replicated_state/src/page_map/storage/tests.rs
/tmp/tmp.meVJxO5BDk/ic/rs/sns/governance/src/gen/ic_sns_governance.pb.v1.rs
/tmp/tmp.meVJxO5BDk/ic/rs/sns/governance/src/governance.rs
/tmp/tmp.meVJxO5BDk/ic/rs/sns/governance/src/neuron.rs
/tmp/tmp.meVJxO5BDk/ic/rs/sns/governance/src/proposal.rs
/tmp/tmp.meVJxO5BDk/ic/rs/sns/governance/src/types.rs
/tmp/tmp.meVJxO5BDk/ic/rs/sns/swap/src/swap.rs
/tmp/tmp.meVJxO5BDk/ic/rs/state_layout/src/state_layout.rs
/tmp/tmp.meVJxO5BDk/ic/rs/sys/src/lib.rs
/tmp/tmp.meVJxO5BDk/ic/rs/sys/src/utility_command.rs
/tmp/tmp.meVJxO5BDk/ic/rs/system_api/src/request_in_prep.rs
/tmp/tmp.meVJxO5BDk/ic/rs/system_api/src/sandbox_safe_system_state.rs
/tmp/tmp.meVJxO5BDk/ic/rs/types/types/src/batch/ingress.rs
/tmp/tmp.meVJxO5BDk/ic/rs/types/types/src/batch/self_validating.rs
/tmp/tmp.meVJxO5BDk/ic/rs/types/types/src/batch/xnet.rs
/tmp/tmp.meVJxO5BDk/ic/rs/types/types/src/canister_http.rs
/tmp/tmp.meVJxO5BDk/ic/rs/types/types/src/consensus.rs
/tmp/tmp.meVJxO5BDk/ic/rs/types/types/src/consensus/catchup.rs
/tmp/tmp.meVJxO5BDk/ic/rs/types/types/src/consensus/dkg.rs
/tmp/tmp.meVJxO5BDk/ic/rs/types/types/src/consensus/hashed.rs
/tmp/tmp.meVJxO5BDk/ic/rs/types/types/src/consensus/idkg.rs
/tmp/tmp.meVJxO5BDk/ic/rs/types/types/src/crypto/canister_threshold_sig/idkg.rs
/tmp/tmp.meVJxO5BDk/ic/rs/utils/thread/src/lib.rs
/tmp/tmp.meVJxO5BDk/ic/rs/xnet/payload_builder/src/lib.rs

Collecting unique commits...
Unique commits that modified the relevant files, with PR links:
0ed8c497c2 test: Fix property tests in bitcoin consensus payload builder (#656)
PR: https://github.com/dfinity/ic/pull/656

204542c152 chore(consensus): change the associated `Error` type of `TryFrom<pb>` from `String` to `ProxyDecodeError` for some consensus types (#695)
PR: https://github.com/dfinity/ic/pull/695

2c8adf74bc chore: Update Base Image Refs [2024-07-31-0139] (#690)
PR: https://github.com/dfinity/ic/pull/690

5e319b9de0 feat(consensus): [CON-1361] Change definition of better to exclude disqualified block makers (#673)
PR: https://github.com/dfinity/ic/pull/673

736beea982 feat(RUN-1030): Enable transparent huge pages for the page allocator (#665)
PR: https://github.com/dfinity/ic/pull/665

96035ca4c1 feat: Reduce DTS slice limit for regular messages on system subnets (#621)
PR: https://github.com/dfinity/ic/pull/621

962bb3848d refactor(consensus): clean up the `dkg::payload_validator` code a bit and increase the test coverage (#661)
PR: https://github.com/dfinity/ic/pull/661

96bc278001 refactor(sns): Add controller and hotkeys information to ClaimSwapNeuronsRequest, and use it in SNS Governance (#596)
PR: https://github.com/dfinity/ic/pull/596

9bc6e18acf chore(neurons_fund): Populate hotkeys when necessary in the NNS Governance → Swap → SNS Governance dataflow (#688)
PR: https://github.com/dfinity/ic/pull/688

a89a2e17cd feat(nns): Metrics for public neurons. (#685)
PR: https://github.com/dfinity/ic/pull/685

b4be567dc0 chore: Bump rust version to 1.80 (#642)
PR: https://github.com/dfinity/ic/pull/642

c77043f06e chore: Update Base Image Refs [2024-08-01-0150] (#712)
PR: https://github.com/dfinity/ic/pull/712

f0093242dc feat: EXC-1644: Enforce taking a canister snapshot only when canister is not empty (#452)
PR: https://github.com/dfinity/ic/pull/452

f6a88d1a56 chore: RUN-1025: Saturate function index in system api calls (#641)
PR: https://github.com/dfinity/ic/pull/641
```