### PR TITLE
standard icrc28

### DIFF
--- a/water_neuron/src/lib.rs
+++ b/water_neuron/src/lib.rs
@@ -149,6 +149,11 @@ pub struct CanisterInfo {
     pub governance_fee_share_percent: u64,
 }
 
+#[derive(CandidType, Serialize)]
+pub struct TrustedOriginsResponse {
+    pub trusted_origins: Vec<String>,
+}
+
 #[derive(CandidType, Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Encode, Decode)]
 pub enum Unit {
     #[n(0)]

--- a/water_neuron/src/main.rs
+++ b/water_neuron/src/main.rs
@@ -23,7 +23,7 @@ use water_neuron::storage::total_event_count;
 use water_neuron::tasks::{schedule_now, TaskType};
 use water_neuron::{
     CancelWithdrawalError, CanisterInfo, ConversionArg, ConversionError, DepositSuccess, LiquidArg,
-    Unit, UpgradeArg, WithdrawalSuccess,
+    TrustedOriginsResponse, Unit, UpgradeArg, WithdrawalSuccess,
 };
 
 fn reject_anonymous_call() {
@@ -346,6 +346,18 @@ async fn icp_to_nicp(arg: ConversionArg) -> Result<DepositSuccess, ConversionErr
 async fn cancel_withdrawal(neuron_id: NeuronId) -> Result<MergeResponse, CancelWithdrawalError> {
     reject_anonymous_call();
     check_postcondition(water_neuron::conversion::cancel_withdrawal(neuron_id).await)
+}
+
+#[query]
+fn icrc28_trusted_origins() -> TrustedOriginsResponse {
+    TrustedOriginsResponse {
+        trusted_origins: vec![
+            "https://47pxu-byaaa-aaaap-ahpsa-cai.icp0.io".to_string(),
+            "http://localhost:3001".to_string(),
+            "https://n3i53-gyaaa-aaaam-acfaq-cai.icp0.io".to_string(),
+            "https://waterneuron.fi".to_string(),
+        ],
+    }
 }
 
 #[query(hidden = true)]

--- a/water_neuron/water_neuron.did
+++ b/water_neuron/water_neuron.did
@@ -230,15 +230,16 @@ type WithdrawalSuccess = record {
   icp_amount : opt nat64;
 };
 service : (LiquidArg) -> {
-  cancel_withdrawal : (NeuronId) -> (Result);
-  claim_airdrop : () -> (Result_1);
   get_airdrop_allocation : (opt principal) -> (nat64) query;
   get_events : (GetEventsArg) -> (GetEventsResult) query;
   get_info : () -> (CanisterInfo) query;
   get_transfer_statuses : (vec nat64) -> (vec TransferStatus) query;
   get_withdrawal_requests : (opt Account) -> (vec WithdrawalDetails) query;
   get_wtn_proposal_id : (nat64) -> (Result_2) query;
-  icp_to_nicp : (ConversionArg) -> (Result_3);
   icrc28_trusted_origins : () -> (TrustedOriginsResponse) query;
+
+  icp_to_nicp : (ConversionArg) -> (Result_3);
   nicp_to_icp : (ConversionArg) -> (Result_4);
-}
+  cancel_withdrawal : (NeuronId) -> (Result);
+  claim_airdrop : () -> (Result_1);
+  }

--- a/water_neuron/water_neuron.did
+++ b/water_neuron/water_neuron.did
@@ -200,6 +200,7 @@ type TransferStatus = variant {
   Unknown;
   Pending : PendingTransfer;
 };
+type TrustedOriginsResponse = record { trusted_origins : vec text };
 type Unit = variant { ICP; WTN; NICP };
 type UpgradeArg = record { governance_fee_share_percent : opt nat64 };
 type WithdrawalDetails = record {
@@ -229,15 +230,15 @@ type WithdrawalSuccess = record {
   icp_amount : opt nat64;
 };
 service : (LiquidArg) -> {
+  cancel_withdrawal : (NeuronId) -> (Result);
+  claim_airdrop : () -> (Result_1);
   get_airdrop_allocation : (opt principal) -> (nat64) query;
   get_events : (GetEventsArg) -> (GetEventsResult) query;
   get_info : () -> (CanisterInfo) query;
   get_transfer_statuses : (vec nat64) -> (vec TransferStatus) query;
   get_withdrawal_requests : (opt Account) -> (vec WithdrawalDetails) query;
   get_wtn_proposal_id : (nat64) -> (Result_2) query;
-  
   icp_to_nicp : (ConversionArg) -> (Result_3);
+  icrc28_trusted_origins : () -> (TrustedOriginsResponse) query;
   nicp_to_icp : (ConversionArg) -> (Result_4);
-  cancel_withdrawal : (NeuronId) -> (Result);
-  claim_airdrop : () -> (Result_1);
 }

--- a/water_neuron/water_neuron.did
+++ b/water_neuron/water_neuron.did
@@ -242,4 +242,4 @@ service : (LiquidArg) -> {
   nicp_to_icp : (ConversionArg) -> (Result_4);
   cancel_withdrawal : (NeuronId) -> (Result);
   claim_airdrop : () -> (Result_1);
-  }
+}


### PR DESCRIPTION
icrc28_trusted_origins works as follows: 
- The backend canister provides an `icrc28_trusted_origins` query specifying trusted URLs. 
- Relying parties associated to those URLs can ask for a partial delegation to identity providers. 
