### PR TITLE
Get rid of icrc34

### DIFF
--- a/water_neuron/src/lib.rs
+++ b/water_neuron/src/lib.rs
@@ -83,9 +83,6 @@ pub const INITIAL_NEURON_STAKE: u64 = E8S + 42;
 
 pub const SNS_DISTRIBUTION_MEMO: u64 = 83_78_83;
 
-// Maximum number of bytes that an argument to a canister call can have when passed to the ICRC-21 endpoint.
-pub const MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES: u16 = 500;
-
 #[cfg(target_arch = "wasm32")]
 pub fn timestamp_nanos() -> u64 {
     ic_cdk::api::time()

--- a/water_neuron/src/lib.rs
+++ b/water_neuron/src/lib.rs
@@ -83,6 +83,9 @@ pub const INITIAL_NEURON_STAKE: u64 = E8S + 42;
 
 pub const SNS_DISTRIBUTION_MEMO: u64 = 83_78_83;
 
+// Maximum number of bytes that an argument to a canister call can have when passed to the ICRC-21 endpoint.
+pub const MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES: u16 = 500;
+
 #[cfg(target_arch = "wasm32")]
 pub fn timestamp_nanos() -> u64 {
     ic_cdk::api::time()
@@ -147,11 +150,6 @@ pub struct CanisterInfo {
     pub minimum_deposit_amount: ICP,
     pub minimum_withdraw_amount: ICP,
     pub governance_fee_share_percent: u64,
-}
-
-#[derive(CandidType, Serialize)]
-pub struct TrustedOriginsResponse {
-    pub trusted_origins: Vec<String>,
 }
 
 #[derive(CandidType, Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Encode, Decode)]

--- a/water_neuron/src/main.rs
+++ b/water_neuron/src/main.rs
@@ -348,18 +348,6 @@ async fn cancel_withdrawal(neuron_id: NeuronId) -> Result<MergeResponse, CancelW
     check_postcondition(water_neuron::conversion::cancel_withdrawal(neuron_id).await)
 }
 
-#[query]
-fn icrc28_trusted_origins() -> TrustedOriginsResponse {
-    TrustedOriginsResponse {
-        trusted_origins: vec![
-            "https://47pxu-byaaa-aaaap-ahpsa-cai.icp0.io".to_string(),
-            "http://localhost:3001".to_string(),
-            "https://n3i53-gyaaa-aaaam-acfaq-cai.icp0.io".to_string(),
-            "https://waterneuron.fi".to_string(),
-        ],
-    }
-}
-
 #[query(hidden = true)]
 fn http_request(req: HttpRequest) -> HttpResponse {
     if req.path() == "/dashboard" {

--- a/water_neuron/water_neuron.did
+++ b/water_neuron/water_neuron.did
@@ -236,8 +236,7 @@ service : (LiquidArg) -> {
   get_transfer_statuses : (vec nat64) -> (vec TransferStatus) query;
   get_withdrawal_requests : (opt Account) -> (vec WithdrawalDetails) query;
   get_wtn_proposal_id : (nat64) -> (Result_2) query;
-  icrc28_trusted_origins : () -> (TrustedOriginsResponse) query;
-
+  
   icp_to_nicp : (ConversionArg) -> (Result_3);
   nicp_to_icp : (ConversionArg) -> (Result_4);
   cancel_withdrawal : (NeuronId) -> (Result);


### PR DESCRIPTION
# What 
Cancelled the previous PR about `icrc28_trusted_origins`. 

# Why
Discussions are going on about the potential flaws of having icrc28 for a DEFI project. 

# How
-Deleting the endpoint
-Updating the candid file
-Deleting unused declarations