### PR TITLE
icrc-10 / icrc-21

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -658,7 +658,7 @@
     },
     "@@rules_rust~//rust:extensions.bzl%rust": {
       "general": {
-        "bzlTransitiveDigest": "oEc6C6WyXAaUFNrJ9x2alYrTMH8lDXLIoMmTdlekEr8=",
+        "bzlTransitiveDigest": "On2S1n4oTTFGUqpJkhIHlFTQsspqPBiMEugWLZhc4jc=",
         "usagesDigest": "66V66w6pUhkB9EhK2d+/X7Ef9LIkYB/h58TcEc+vPEI=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/water_neuron/src/icrc21.rs
+++ b/water_neuron/src/icrc21.rs
@@ -1,9 +1,8 @@
 use candid::{CandidType, Decode, Deserialize};
-use ic_cdk_macros::{query, update};
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
-use water_neuron::nns_types::NeuronId;
-use water_neuron::ConversionArg;
+use crate::nns_types::NeuronId;
+use crate::ConversionArg;
 
 // Maximum number of bytes for a WaterNeuron call argument passed to the ICRC-21 endpoint.
 pub const MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES: u16 = 500;
@@ -91,8 +90,7 @@ pub fn convert_amount_e8s_to_string_representation(amount_e8s: u64, decimals: i3
     format!("{}", (amount_e8s as f64) / 10_f64.powi(decimals))
 }
 
-#[query]
-fn icrc10_supported_standards() -> Vec<StandardRecord> {
+pub fn icrc10_supported_standards() -> Vec<StandardRecord> {
     vec![
         StandardRecord {
             name: "ICRC-21".to_string(),
@@ -101,8 +99,7 @@ fn icrc10_supported_standards() -> Vec<StandardRecord> {
     ]
 }
 
-#[update]
-fn icrc21_canister_call_consent_message(
+pub fn icrc21_canister_call_consent_message(
     request: ConsentMessageRequest,
 ) -> Result<ConsentInfo, Icrc21Error> {
     if request.arg.len() > MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES as usize {

--- a/water_neuron/src/icrc21.rs
+++ b/water_neuron/src/icrc21.rs
@@ -87,11 +87,6 @@ pub struct ErrorInfo {
     pub description: String,
 }
 
-pub fn convert_amount_e8s_to_string_representation(amount_e8s: u64) -> String {
-    let amount_to_display = DisplayAmount(amount_e8s);
-    format!("{}", amount_to_display)
-}
-
 pub fn icrc10_supported_standards() -> Vec<StandardRecord> {
     vec![
         StandardRecord {
@@ -132,7 +127,7 @@ pub fn icrc21_canister_call_consent_message(
             let arg = Decode!(&request.arg, ConversionArg).map_err(|e| Icrc21Error::UnsupportedCanisterCall(ErrorInfo {
                 description: format!("Failed to decode ConversionArg: {}", e)
             }))?;
-            let icp_amount = convert_amount_e8s_to_string_representation(arg.amount_e8s);
+            let icp_amount = format!("{}", DisplayAmount(arg.amount_e8s));
             match arg.maybe_subaccount {
                 Some(subaccount) => format!("Convert {icp_amount} ICP to nICP at the current exchange rate. Specified subaccount: {subaccount:?}."),
                 None => format!("Convert {icp_amount} ICP to nICP at the current exchange rate.")
@@ -142,7 +137,7 @@ pub fn icrc21_canister_call_consent_message(
             let arg = Decode!(&request.arg, ConversionArg).map_err(|e| Icrc21Error::UnsupportedCanisterCall(ErrorInfo {
                 description: format!("Failed to decode ConversionArg: {}", e),
             }))?;
-            let nicp_amount = convert_amount_e8s_to_string_representation(arg.amount_e8s);
+            let nicp_amount = format!("{}", DisplayAmount(arg.amount_e8s));
             match arg.maybe_subaccount {
                 Some(subaccount) => format!(
                     "Convert {nicp_amount} nICP to ICP at the current exchange rate after a 6 months dissolve delay. 

--- a/water_neuron/src/icrc21.rs
+++ b/water_neuron/src/icrc21.rs
@@ -127,10 +127,9 @@ pub fn icrc21_canister_call_consent_message(
             let arg = Decode!(&request.arg, ConversionArg).map_err(|e| Icrc21Error::UnsupportedCanisterCall(ErrorInfo {
                 description: format!("Failed to decode ConversionArg: {}", e)
             }))?;
-            let icp_amount = format!("{}", DisplayAmount(arg.amount_e8s));
             match arg.maybe_subaccount {
-                Some(subaccount) => format!("Convert {icp_amount} ICP to nICP at the current exchange rate. Specified subaccount: {subaccount:?}."),
-                None => format!("Convert {icp_amount} ICP to nICP at the current exchange rate.")
+                Some(subaccount) => format!("Convert {} ICP to nICP at the current exchange rate. Specified subaccount: {}.", DisplayAmount(arg.amount_e8s), hex::encode(subaccount)),
+                None => format!("Convert {} ICP to nICP at the current exchange rate.", DisplayAmount(arg.amount_e8s))
             }
         },
         Icrc21Function::Unstake =>  {

--- a/water_neuron/src/icrc21.rs
+++ b/water_neuron/src/icrc21.rs
@@ -1,8 +1,8 @@
+use crate::nns_types::NeuronId;
+use crate::ConversionArg;
 use candid::{CandidType, Decode, Deserialize};
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
-use crate::nns_types::NeuronId;
-use crate::ConversionArg;
 
 // Maximum number of bytes for a WaterNeuron call argument passed to the ICRC-21 endpoint.
 pub const MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES: u16 = 500;

--- a/water_neuron/src/icrc21.rs
+++ b/water_neuron/src/icrc21.rs
@@ -1,0 +1,172 @@
+use candid::{CandidType, Decode, Deserialize};
+use ic_cdk_macros::{query, update};
+use strum::IntoEnumIterator;
+use strum_macros::{Display, EnumIter, EnumString};
+use water_neuron::nns_types::NeuronId;
+use water_neuron::ConversionArg;
+
+// Maximum number of bytes for a WaterNeuron call argument passed to the ICRC-21 endpoint.
+pub const MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES: u16 = 500;
+
+#[derive(Debug, EnumString, EnumIter, Display)]
+pub enum Icrc21Function {
+    #[strum(serialize = "icp_to_nicp")]
+    Stake,
+    #[strum(serialize = "nicp_to_icp")]
+    Unstake,
+    #[strum(serialize = "cancel_withdrawal")]
+    CancelWithdrawal,
+    #[strum(serialize = "claim_airdrop")]
+    ClaimAirdrop,
+}
+
+#[derive(CandidType, Deserialize)]
+pub struct StandardRecord {
+    pub url: String,
+    pub name: String,
+}
+
+#[derive(CandidType, Deserialize)]
+pub struct ConsentMessageRequest {
+    pub arg: Vec<u8>,
+    pub method: String,
+    pub user_preferences: ConsentMessageSpec,
+}
+
+#[derive(CandidType, Deserialize)]
+pub struct ConsentMessageSpec {
+    pub metadata: ConsentMessageMetadata,
+    pub device_spec: Option<DisplayMessageType>,
+}
+
+#[derive(CandidType, Deserialize)]
+pub struct ConsentMessageMetadata {
+    pub utc_offset_minutes: Option<u16>,
+    pub language: String,
+}
+
+#[derive(CandidType, Deserialize)]
+pub enum DisplayMessageType {
+    GenericDisplay,
+    LineDisplay {
+        characters_per_line: u16,
+        lines_per_page: u16,
+    },
+}
+
+#[derive(CandidType, Deserialize)]
+pub struct ConsentInfo {
+    pub metadata: ConsentMessageMetadata,
+    pub consent_message: ConsentMessage,
+}
+
+#[derive(CandidType, Deserialize)]
+pub enum ConsentMessage {
+    LineDisplayMessage { pages: Vec<LineDisplayPage> },
+    GenericDisplayMessage(String),
+}
+
+#[derive(CandidType, Deserialize)]
+pub struct LineDisplayPage {
+    lines: Vec<String>,
+}
+
+#[derive(CandidType, Deserialize)]
+pub enum Icrc21Error {
+    GenericError {
+        description: String,
+        error_code: u64,
+    },
+    InsufficientPayment(ErrorInfo),
+    UnsupportedCanisterCall(ErrorInfo),
+    ConsentMessageUnavailable(ErrorInfo),
+}
+
+#[derive(CandidType, Deserialize)]
+pub struct ErrorInfo {
+    pub description: String,
+}
+
+pub fn convert_amount_e8s_to_string_representation(amount_e8s: u64, decimals: i32) -> String {
+    format!("{}", (amount_e8s as f64) / 10_f64.powi(decimals))
+}
+
+#[query]
+fn icrc10_supported_standards() -> Vec<StandardRecord> {
+    vec![
+        StandardRecord {
+            name: "ICRC-21".to_string(),
+            url: "https://github.com/dfinity/wg-identity-authentication/blob/main/topics/ICRC-21/icrc_21_consent_msg.md".to_string(),
+        }
+    ]
+}
+
+#[update]
+fn icrc21_canister_call_consent_message(
+    request: ConsentMessageRequest,
+) -> Result<ConsentInfo, Icrc21Error> {
+    if request.arg.len() > MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES as usize {
+        return Err(Icrc21Error::UnsupportedCanisterCall(ErrorInfo {
+            description: format!(
+                "The argument size is too large. The maximum allowed size is {} bytes.",
+                MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES
+            ),
+        }));
+    }
+
+    let metadata = ConsentMessageMetadata {
+        language: "en".to_string(),
+        utc_offset_minutes: request.user_preferences.metadata.utc_offset_minutes,
+    };
+
+    let message = match request.method.parse::<Icrc21Function>().map_err(|err| {
+        Icrc21Error::UnsupportedCanisterCall(ErrorInfo {
+            description: format!(
+                "The call provided is not supported: {}.\n Supported calls for ICRC-21 are {:?}. \n Error: {:?}", 
+                request.method,
+                Icrc21Function::iter().map(|f|f.to_string()).collect::<Vec<String>>(),
+                err
+            ),
+        })
+    })? {
+        Icrc21Function::Stake =>  {
+            let arg = Decode!(&request.arg, ConversionArg).map_err(|e| Icrc21Error::UnsupportedCanisterCall(ErrorInfo {
+                description: format!("Failed to decode ConversionArg: {}", e)
+            }))?;
+            let icp_amount = convert_amount_e8s_to_string_representation(arg.amount_e8s, 8);
+            match arg.maybe_subaccount {
+                Some(subaccount) => format!("Convert {icp_amount} ICP to nICP at the current exchange rate. Specified subaccount: {subaccount:?}."),
+                None => format!("Convert {icp_amount} ICP to nICP at the current exchange rate.")
+            }
+        },
+        Icrc21Function::Unstake =>  {
+            let arg = Decode!(&request.arg, ConversionArg).map_err(|e| Icrc21Error::UnsupportedCanisterCall(ErrorInfo {
+                description: format!("Failed to decode ConversionArg: {}", e),
+            }))?;
+            let nicp_amount = convert_amount_e8s_to_string_representation(arg.amount_e8s, 8);
+            match arg.maybe_subaccount {
+                Some(subaccount) => format!(
+                    "Convert {nicp_amount} nICP to ICP at the current exchange rate after a 6 months dissolve delay. 
+                    Specified subaccount: {subaccount:?}."
+                ),
+                None => format!(
+                    "Convert {nicp_amount} nICP to ICP at the current exchange rate after a 6 months dissolve delay."
+                )
+            }
+        },
+        Icrc21Function::CancelWithdrawal =>  {
+            let arg = Decode!(&request.arg, NeuronId).map_err(|e| Icrc21Error::UnsupportedCanisterCall(ErrorInfo {
+                description: format!("Failed to decode NeuronId: {}", e),
+            }))?;
+            format!("Cancel the withdrawal associated to the neuron id: {}.", arg.id)
+        },
+        Icrc21Function::ClaimAirdrop =>  {
+            format!("Claim WTN tokens associated to your airdrop allocation. ")
+        }
+    };
+
+    Ok(ConsentInfo {
+        metadata,
+        consent_message: ConsentMessage::GenericDisplayMessage(message),
+    })
+}

--- a/water_neuron/src/icrc21.rs
+++ b/water_neuron/src/icrc21.rs
@@ -128,7 +128,11 @@ pub fn icrc21_canister_call_consent_message(
                 description: format!("Failed to decode ConversionArg: {}", e)
             }))?;
             match arg.maybe_subaccount {
-                Some(subaccount) => format!("Convert {} ICP to nICP at the current exchange rate. Specified subaccount: {}.", DisplayAmount(arg.amount_e8s), hex::encode(subaccount)),
+                Some(subaccount) => format!("Convert {} ICP to nICP at the current exchange rate. 
+                    Specified subaccount: {}.", 
+                    DisplayAmount(arg.amount_e8s),
+                    hex::encode(subaccount)
+                ),
                 None => format!("Convert {} ICP to nICP at the current exchange rate.", DisplayAmount(arg.amount_e8s))
             }
         },
@@ -136,14 +140,16 @@ pub fn icrc21_canister_call_consent_message(
             let arg = Decode!(&request.arg, ConversionArg).map_err(|e| Icrc21Error::UnsupportedCanisterCall(ErrorInfo {
                 description: format!("Failed to decode ConversionArg: {}", e),
             }))?;
-            let nicp_amount = format!("{}", DisplayAmount(arg.amount_e8s));
             match arg.maybe_subaccount {
                 Some(subaccount) => format!(
-                    "Convert {nicp_amount} nICP to ICP at the current exchange rate after a 6 months dissolve delay. 
-                    Specified subaccount: {subaccount:?}."
+                    "Convert {} nICP to ICP at the current exchange rate after a 6 months dissolve delay. 
+                    Specified subaccount: {}.", 
+                    DisplayAmount(arg.amount_e8s),
+                    hex::encode(subaccount)
                 ),
                 None => format!(
-                    "Convert {nicp_amount} nICP to ICP at the current exchange rate after a 6 months dissolve delay."
+                    "Convert {} nICP to ICP at the current exchange rate after a 6 months dissolve delay.",
+                    DisplayAmount(arg.amount_e8s)
                 )
             }
         },

--- a/water_neuron/src/icrc21.rs
+++ b/water_neuron/src/icrc21.rs
@@ -1,3 +1,4 @@
+use crate::dashboard::DisplayAmount;
 use crate::nns_types::NeuronId;
 use crate::ConversionArg;
 use candid::{CandidType, Decode, Deserialize};
@@ -86,8 +87,9 @@ pub struct ErrorInfo {
     pub description: String,
 }
 
-pub fn convert_amount_e8s_to_string_representation(amount_e8s: u64, decimals: i32) -> String {
-    format!("{}", (amount_e8s as f64) / 10_f64.powi(decimals))
+pub fn convert_amount_e8s_to_string_representation(amount_e8s: u64) -> String {
+    let amount_to_display = DisplayAmount(amount_e8s);
+    format!("{}", amount_to_display)
 }
 
 pub fn icrc10_supported_standards() -> Vec<StandardRecord> {
@@ -130,7 +132,7 @@ pub fn icrc21_canister_call_consent_message(
             let arg = Decode!(&request.arg, ConversionArg).map_err(|e| Icrc21Error::UnsupportedCanisterCall(ErrorInfo {
                 description: format!("Failed to decode ConversionArg: {}", e)
             }))?;
-            let icp_amount = convert_amount_e8s_to_string_representation(arg.amount_e8s, 8);
+            let icp_amount = convert_amount_e8s_to_string_representation(arg.amount_e8s);
             match arg.maybe_subaccount {
                 Some(subaccount) => format!("Convert {icp_amount} ICP to nICP at the current exchange rate. Specified subaccount: {subaccount:?}."),
                 None => format!("Convert {icp_amount} ICP to nICP at the current exchange rate.")
@@ -140,7 +142,7 @@ pub fn icrc21_canister_call_consent_message(
             let arg = Decode!(&request.arg, ConversionArg).map_err(|e| Icrc21Error::UnsupportedCanisterCall(ErrorInfo {
                 description: format!("Failed to decode ConversionArg: {}", e),
             }))?;
-            let nicp_amount = convert_amount_e8s_to_string_representation(arg.amount_e8s, 8);
+            let nicp_amount = convert_amount_e8s_to_string_representation(arg.amount_e8s);
             match arg.maybe_subaccount {
                 Some(subaccount) => format!(
                     "Convert {nicp_amount} nICP to ICP at the current exchange rate after a 6 months dissolve delay. 

--- a/water_neuron/src/lib.rs
+++ b/water_neuron/src/lib.rs
@@ -32,7 +32,7 @@ use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
 use std::fmt;
 use std::time::Duration;
-use strum::{self, IntoEnumIterator};
+use strum::IntoEnumIterator;
 
 pub mod cbor;
 pub mod conversion;

--- a/water_neuron/src/lib.rs
+++ b/water_neuron/src/lib.rs
@@ -38,6 +38,7 @@ pub mod cbor;
 pub mod conversion;
 pub mod dashboard;
 pub mod guards;
+pub mod icrc21;
 pub mod logs;
 pub mod management;
 pub mod nns_types;

--- a/water_neuron/src/lib.rs
+++ b/water_neuron/src/lib.rs
@@ -33,7 +33,6 @@ use std::cmp::Ordering;
 use std::fmt;
 use std::time::Duration;
 use strum::{self, IntoEnumIterator};
-use strum_macros::{Display, EnumIter, EnumString};
 
 pub mod cbor;
 pub mod conversion;
@@ -83,9 +82,6 @@ const MINIMUM_ICP_DISTRIBUTION: u64 = 100 * E8S;
 pub const INITIAL_NEURON_STAKE: u64 = E8S + 42;
 
 pub const SNS_DISTRIBUTION_MEMO: u64 = 83_78_83;
-
-// Maximum number of bytes for a WaterNeuron call argument passed to the ICRC-21 endpoint.
-pub const MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES: u16 = 500;
 
 #[cfg(target_arch = "wasm32")]
 pub fn timestamp_nanos() -> u64 {
@@ -151,89 +147,6 @@ pub struct CanisterInfo {
     pub minimum_deposit_amount: ICP,
     pub minimum_withdraw_amount: ICP,
     pub governance_fee_share_percent: u64,
-}
-
-#[derive(Debug, EnumString, EnumIter, Display)]
-pub enum Icrc21Function {
-    #[strum(serialize = "icp_to_nicp")]
-    Stake,
-    #[strum(serialize = "nicp_to_icp")]
-    Unstake,
-    #[strum(serialize = "cancel_withdrawal")]
-    CancelWithdrawal,
-    #[strum(serialize = "claim_airdrop")]
-    ClaimAirdrop,
-}
-
-#[derive(CandidType, Deserialize)]
-pub struct StandardRecord {
-    pub url: String,
-    pub name: String,
-}
-
-#[derive(CandidType, Deserialize)]
-pub struct ConsentMessageRequest {
-    pub arg: Vec<u8>,
-    pub method: String,
-    pub user_preferences: ConsentMessageSpec,
-}
-
-#[derive(CandidType, Deserialize)]
-pub struct ConsentMessageSpec {
-    pub metadata: ConsentMessageMetadata,
-    pub device_spec: Option<DisplayMessageType>,
-}
-
-#[derive(CandidType, Deserialize)]
-pub struct ConsentMessageMetadata {
-    pub utc_offset_minutes: Option<u16>,
-    pub language: String,
-}
-
-#[derive(CandidType, Deserialize)]
-pub enum DisplayMessageType {
-    GenericDisplay,
-    LineDisplay {
-        characters_per_line: u16,
-        lines_per_page: u16,
-    },
-}
-
-#[derive(CandidType, Deserialize)]
-pub struct ConsentInfo {
-    pub metadata: ConsentMessageMetadata,
-    pub consent_message: ConsentMessage,
-}
-
-#[derive(CandidType, Deserialize)]
-pub enum ConsentMessage {
-    LineDisplayMessage { pages: Vec<LineDisplayPage> },
-    GenericDisplayMessage(String),
-}
-
-#[derive(CandidType, Deserialize)]
-pub struct LineDisplayPage {
-    lines: Vec<String>,
-}
-
-#[derive(CandidType, Deserialize)]
-pub enum Icrc21Error {
-    GenericError {
-        description: String,
-        error_code: u64,
-    },
-    InsufficientPayment(ErrorInfo),
-    UnsupportedCanisterCall(ErrorInfo),
-    ConsentMessageUnavailable(ErrorInfo),
-}
-
-#[derive(CandidType, Deserialize)]
-pub struct ErrorInfo {
-    pub description: String,
-}
-
-pub fn convert_amount_e8s_to_string_representation(amount_e8s: u64, decimals: i32) -> String {
-    format!("{}", (amount_e8s as f64) / 10_f64.powi(decimals))
 }
 
 #[derive(CandidType, Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Encode, Decode)]

--- a/water_neuron/src/lib.rs
+++ b/water_neuron/src/lib.rs
@@ -166,7 +166,7 @@ pub enum Icrc21Function {
 }
 
 #[derive(CandidType, Deserialize)]
-pub struct SupportedStandard {
+pub struct StandardRecord {
     pub url: String,
     pub name: String,
 }

--- a/water_neuron/src/main.rs
+++ b/water_neuron/src/main.rs
@@ -24,7 +24,7 @@ use water_neuron::tasks::{schedule_now, TaskType};
 use water_neuron::{
     convert_amount_e8s_to_string_representation, CancelWithdrawalError, CanisterInfo, ConsentInfo,
     ConsentMessageMetadata, ConsentMessageRequest, ConversionArg, ConversionError, DepositSuccess,
-    ErrorInfo, Icrc21Error, Icrc21Function, LiquidArg, SupportedStandard,
+    ErrorInfo, Icrc21Error, Icrc21Function, LiquidArg, StandardRecord,
     Unit, UpgradeArg, WithdrawalSuccess, MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES, ConsentMessage
 };
 use strum::IntoEnumIterator;
@@ -174,9 +174,9 @@ fn get_wtn_proposal_id(nns_proposal_id: u64) -> Result<ProposalId, ProposalId> {
 }
 
 #[query]
-fn icrc10_supported_standards() -> Vec<SupportedStandard> {
+fn icrc10_supported_standards() -> Vec<StandardRecord> {
     vec![
-        SupportedStandard {
+        StandardRecord {
             name: "ICRC-21".to_string(),
             url: "https://github.com/dfinity/wg-identity-authentication/blob/main/topics/ICRC-21/icrc_21_consent_msg.md".to_string(),
         }

--- a/water_neuron/src/main.rs
+++ b/water_neuron/src/main.rs
@@ -217,7 +217,7 @@ fn icrc21_canister_call_consent_message(
             }))?;
             let icp_amount = convert_amount_e8s_to_string_representation(arg.amount_e8s, 8);
             match arg.maybe_subaccount {
-                Some(subaccount) => format!("Convert {icp_amount} ICP to nICP at the current exchange rate. Specified subaccount: {subaccount:?}"),
+                Some(subaccount) => format!("Convert {icp_amount} ICP to nICP at the current exchange rate. Specified subaccount: {subaccount:?}."),
                 None => format!("Convert {icp_amount} ICP to nICP at the current exchange rate.")
             }
         },
@@ -228,11 +228,11 @@ fn icrc21_canister_call_consent_message(
             let nicp_amount = convert_amount_e8s_to_string_representation(arg.amount_e8s, 8);
             match arg.maybe_subaccount {
                 Some(subaccount) => format!(
-                    "Convert {nicp_amount} nICP to ICP at the current exchange rate with a dissolve delay of 6 months. 
-                    Specified subaccount: {subaccount:?}"
+                    "Convert {nicp_amount} nICP to ICP at the current exchange rate after a 6 months dissolve delay. 
+                    Specified subaccount: {subaccount:?}."
                 ),
                 None => format!(
-                    "Convert {nicp_amount} nICP to ICP at the current exchange rate with a dissolve delay of 6 months."
+                    "Convert {nicp_amount} nICP to ICP at the current exchange rate after a 6 months dissolve delay."
                 )
             }
         },

--- a/water_neuron/src/main.rs
+++ b/water_neuron/src/main.rs
@@ -7,6 +7,7 @@ use icrc_ledger_types::icrc1::account::Account;
 use water_neuron::conversion::{MINIMUM_DEPOSIT_AMOUNT, MINIMUM_WITHDRAWAL_AMOUNT};
 use water_neuron::dashboard::DisplayAmount;
 use water_neuron::guards::GuardPrincipal;
+use water_neuron::icrc21::{ConsentInfo, ConsentMessageRequest, Icrc21Error, StandardRecord};
 use water_neuron::logs::INFO;
 use water_neuron::management::register_vote;
 use water_neuron::nns_types::{
@@ -25,7 +26,6 @@ use water_neuron::{
     CancelWithdrawalError, CanisterInfo, ConversionArg, ConversionError, DepositSuccess, LiquidArg,
     Unit, UpgradeArg, WithdrawalSuccess,
 };
-use water_neuron::icrc21::{Icrc21Error, ConsentInfo, ConsentMessageRequest, StandardRecord};
 
 fn reject_anonymous_call() {
     if ic_cdk::caller() == Principal::anonymous() {

--- a/water_neuron/src/main.rs
+++ b/water_neuron/src/main.rs
@@ -4,6 +4,7 @@ use ic_canisters_http_types::{HttpRequest, HttpResponse, HttpResponseBuilder};
 use ic_cdk_macros::{init, post_upgrade, query, update};
 use ic_metrics_encoder::MetricsEncoder;
 use icrc_ledger_types::icrc1::account::Account;
+use strum::IntoEnumIterator;
 use water_neuron::conversion::{MINIMUM_DEPOSIT_AMOUNT, MINIMUM_WITHDRAWAL_AMOUNT};
 use water_neuron::dashboard::DisplayAmount;
 use water_neuron::guards::GuardPrincipal;
@@ -23,11 +24,10 @@ use water_neuron::storage::total_event_count;
 use water_neuron::tasks::{schedule_now, TaskType};
 use water_neuron::{
     convert_amount_e8s_to_string_representation, CancelWithdrawalError, CanisterInfo, ConsentInfo,
-    ConsentMessageMetadata, ConsentMessageRequest, ConversionArg, ConversionError, DepositSuccess,
-    ErrorInfo, Icrc21Error, Icrc21Function, LiquidArg, StandardRecord,
-    Unit, UpgradeArg, WithdrawalSuccess, MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES, ConsentMessage
+    ConsentMessage, ConsentMessageMetadata, ConsentMessageRequest, ConversionArg, ConversionError,
+    DepositSuccess, ErrorInfo, Icrc21Error, Icrc21Function, LiquidArg, StandardRecord, Unit,
+    UpgradeArg, WithdrawalSuccess, MAX_CONSENT_MESSAGE_ARG_SIZE_BYTES,
 };
-use strum::IntoEnumIterator;
 
 fn reject_anonymous_call() {
     if ic_cdk::caller() == Principal::anonymous() {
@@ -198,10 +198,7 @@ fn icrc21_canister_call_consent_message(
 
     let metadata = ConsentMessageMetadata {
         language: "en".to_string(),
-        utc_offset_minutes: request
-            .user_preferences
-            .metadata
-            .utc_offset_minutes,
+        utc_offset_minutes: request.user_preferences.metadata.utc_offset_minutes,
     };
 
     let message = match request.method.parse::<Icrc21Function>().map_err(|err| {

--- a/water_neuron/src/main.rs
+++ b/water_neuron/src/main.rs
@@ -25,8 +25,7 @@ use water_neuron::{
     CancelWithdrawalError, CanisterInfo, ConversionArg, ConversionError, DepositSuccess, LiquidArg,
     Unit, UpgradeArg, WithdrawalSuccess,
 };
-
-pub mod icrc21;
+use water_neuron::icrc21::{Icrc21Error, ConsentInfo, ConsentMessageRequest, StandardRecord};
 
 fn reject_anonymous_call() {
     if ic_cdk::caller() == Principal::anonymous() {
@@ -348,6 +347,18 @@ async fn icp_to_nicp(arg: ConversionArg) -> Result<DepositSuccess, ConversionErr
 async fn cancel_withdrawal(neuron_id: NeuronId) -> Result<MergeResponse, CancelWithdrawalError> {
     reject_anonymous_call();
     check_postcondition(water_neuron::conversion::cancel_withdrawal(neuron_id).await)
+}
+
+#[query]
+fn icrc10_supported_standards() -> Vec<StandardRecord> {
+    water_neuron::icrc21::icrc10_supported_standards()
+}
+
+#[update]
+fn icrc21_canister_call_consent_message(
+    request: ConsentMessageRequest,
+) -> Result<ConsentInfo, Icrc21Error> {
+    water_neuron::icrc21::icrc21_canister_call_consent_message(request)
 }
 
 #[query(hidden = true)]

--- a/water_neuron/water_neuron.did
+++ b/water_neuron/water_neuron.did
@@ -202,13 +202,12 @@ type PendingTransfer = record {
   amount : nat64;
   receiver : Account;
 };
-type Result = variant { Ok : ConsentInfo; Err : Icrc21Error };
-type Result_1 = variant { Ok : NeuronId; Err : NeuronId };
-type Result_2 = variant { Ok : DepositSuccess; Err : ConversionError };
-type Result_3 = variant { Ok : WithdrawalSuccess; Err : ConversionError };
-type Result_4 = variant { Ok : MergeResponse; Err : CancelWithdrawalError };
-type Result_5 = variant { Ok : nat64; Err : ConversionError };
-
+type Result = variant { Ok : MergeResponse; Err : CancelWithdrawalError };
+type Result_1 = variant { Ok : nat64; Err : ConversionError };
+type Result_2 = variant { Ok : NeuronId; Err : NeuronId };
+type Result_3 = variant { Ok : DepositSuccess; Err : ConversionError };
+type Result_5 = variant { Ok : ConsentInfo; Err : Icrc21Error };
+type Result_4 = variant { Ok : WithdrawalSuccess; Err : ConversionError };
 type StandardRecord = record { url : text; name : text };
 type TransferError = variant {
   GenericError : record { message : text; error_code : nat };
@@ -270,12 +269,12 @@ service : (LiquidArg) -> {
   get_info : () -> (CanisterInfo) query;
   get_transfer_statuses : (vec nat64) -> (vec TransferStatus) query;
   get_withdrawal_requests : (opt Account) -> (vec WithdrawalDetails) query;
-  get_wtn_proposal_id : (nat64) -> (Result_1) query;
+  get_wtn_proposal_id : (nat64) -> (Result_2) query;
   icrc10_supported_standards : () -> (vec StandardRecord) query;
-  icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result);
+  icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result_5);
 
-  icp_to_nicp : (ConversionArg) -> (Result_2);
-  nicp_to_icp : (ConversionArg) -> (Result_3);
-  cancel_withdrawal : (NeuronId) -> (Result_4);
-  claim_airdrop : () -> (Result_5);
+  icp_to_nicp : (ConversionArg) -> (Result_3);
+  nicp_to_icp : (ConversionArg) -> (Result_4);
+  cancel_withdrawal : (NeuronId) -> (Result);
+  claim_airdrop : () -> (Result_1);
 }

--- a/water_neuron/water_neuron.did
+++ b/water_neuron/water_neuron.did
@@ -236,7 +236,8 @@ service : (LiquidArg) -> {
   get_transfer_statuses : (vec nat64) -> (vec TransferStatus) query;
   get_withdrawal_requests : (opt Account) -> (vec WithdrawalDetails) query;
   get_wtn_proposal_id : (nat64) -> (Result_2) query;
-  
+  icrc1_supported_standards : () -> (vec SupportedStandard) query;
+
   icp_to_nicp : (ConversionArg) -> (Result_3);
   nicp_to_icp : (ConversionArg) -> (Result_4);
   cancel_withdrawal : (NeuronId) -> (Result);

--- a/water_neuron/water_neuron.did
+++ b/water_neuron/water_neuron.did
@@ -30,6 +30,27 @@ type CanisterInfo = record {
   total_icp_deposited : nat64;
   stakers_count : nat64;
 };
+type ConsentInfo = record {
+  metadata : ConsentMessageMetadata;
+  consent_message : ConsentMessage;
+};
+type ConsentMessage = variant {
+  LineDisplayMessage : record { pages : vec LineDisplayPage };
+  GenericDisplayMessage : text;
+};
+type ConsentMessageMetadata = record {
+  utc_offset_minutes : opt nat16;
+  language : text;
+};
+type ConsentMessageRequest = record {
+  arg : blob;
+  method : text;
+  user_preferences : ConsentMessageSpec;
+};
+type ConsentMessageSpec = record {
+  metadata : ConsentMessageMetadata;
+  device_spec : opt DisplayMessageType;
+};
 type ConversionArg = record { maybe_subaccount : opt blob; amount_e8s : nat64 };
 type ConversionError = variant {
   GenericError : record { code : int32; message : text };
@@ -43,10 +64,15 @@ type DepositSuccess = record {
   block_index : nat;
   transfer_id : nat64;
 };
+type DisplayMessageType = variant {
+  GenericDisplay;
+  LineDisplay : record { characters_per_line : nat16; lines_per_page : nat16 };
+};
 type DissolveState = variant {
   DissolveDelaySeconds : nat64;
   WhenDissolvedTimestampSeconds : nat64;
 };
+type ErrorInfo = record { description : text };
 type Event = record { timestamp : nat64; payload : EventType };
 type EventType = variant {
   ClaimedAirdrop : record { block_index : nat64; caller : principal };
@@ -101,12 +127,19 @@ type GetEventsArg = record { start : nat64; length : nat64 };
 type GetEventsResult = record { total_event_count : nat64; events : vec Event };
 type GovernanceError = record { error_message : text; error_type : int32 };
 type GuardError = variant { AlreadyProcessing; TooManyConcurrentRequests };
+type Icrc21Error = variant {
+  GenericError : record { description : text; error_code : nat64 };
+  InsufficientPayment : ErrorInfo;
+  UnsupportedCanisterCall : ErrorInfo;
+  ConsentMessageUnavailable : ErrorInfo;
+};
 type InitArg = record {
   wtn_ledger_id : principal;
   wtn_governance_id : principal;
   nicp_ledger_id : principal;
 };
 type KnownNeuronData = record { name : text; description : opt text };
+type LineDisplayPage = record { lines : vec text };
 type LiquidArg = variant { Upgrade : opt UpgradeArg; Init : InitArg };
 type MergeResponse = record {
   target_neuron : opt Neuron;
@@ -169,11 +202,14 @@ type PendingTransfer = record {
   amount : nat64;
   receiver : Account;
 };
-type Result = variant { Ok : MergeResponse; Err : CancelWithdrawalError };
-type Result_1 = variant { Ok : nat64; Err : ConversionError };
-type Result_2 = variant { Ok : NeuronId; Err : NeuronId };
-type Result_3 = variant { Ok : DepositSuccess; Err : ConversionError };
-type Result_4 = variant { Ok : WithdrawalSuccess; Err : ConversionError };
+type Result = variant { Ok : ConsentInfo; Err : Icrc21Error };
+type Result_1 = variant { Ok : NeuronId; Err : NeuronId };
+type Result_2 = variant { Ok : DepositSuccess; Err : ConversionError };
+type Result_3 = variant { Ok : WithdrawalSuccess; Err : ConversionError };
+type Result_4 = variant { Ok : MergeResponse; Err : CancelWithdrawalError };
+type Result_5 = variant { Ok : nat64; Err : ConversionError };
+
+type StandardRecord = record { url : text; name : text };
 type TransferError = variant {
   GenericError : record { message : text; error_code : nat };
   TemporarilyUnavailable;
@@ -200,7 +236,6 @@ type TransferStatus = variant {
   Unknown;
   Pending : PendingTransfer;
 };
-type TrustedOriginsResponse = record { trusted_origins : vec text };
 type Unit = variant { ICP; WTN; NICP };
 type UpgradeArg = record { governance_fee_share_percent : opt nat64 };
 type WithdrawalDetails = record {
@@ -235,11 +270,12 @@ service : (LiquidArg) -> {
   get_info : () -> (CanisterInfo) query;
   get_transfer_statuses : (vec nat64) -> (vec TransferStatus) query;
   get_withdrawal_requests : (opt Account) -> (vec WithdrawalDetails) query;
-  get_wtn_proposal_id : (nat64) -> (Result_2) query;
-  icrc1_supported_standards : () -> (vec SupportedStandard) query;
+  get_wtn_proposal_id : (nat64) -> (Result_1) query;
+  icrc10_supported_standards : () -> (vec StandardRecord) query;
+  icrc21_canister_call_consent_message : (ConsentMessageRequest) -> (Result);
 
-  icp_to_nicp : (ConversionArg) -> (Result_3);
-  nicp_to_icp : (ConversionArg) -> (Result_4);
-  cancel_withdrawal : (NeuronId) -> (Result);
-  claim_airdrop : () -> (Result_1);
+  icp_to_nicp : (ConversionArg) -> (Result_2);
+  nicp_to_icp : (ConversionArg) -> (Result_3);
+  cancel_withdrawal : (NeuronId) -> (Result_4);
+  claim_airdrop : () -> (Result_5);
 }


### PR DESCRIPTION
# What
This PR implements both standards icrc-10 and icrc-21. 

# Why
The Oisy wallet does not accept calls from backend canisters not implementing the icrc-21 standard. 

# How
Adding the following endpoints: 
- `icrc10_supported_standards` (query)
- `icrc21_canister_call_consent_message` (update)