### PR TITLE
Only bump `last_nns_proposal_processed` once SNS proposal is pushed

### DIFF
--- a/water_neuron/src/main.rs
+++ b/water_neuron/src/main.rs
@@ -74,7 +74,7 @@ pub fn post_upgrade(args: LiquidArg) {
 
             mutate_state(|s| {
                 if let Some(entry) = s.proposals.last_entry() {
-                    s.last_nns_proposal_seen = entry.key().clone();
+                    s.last_nns_proposal_processed = entry.key().clone();
                 }
             });
 
@@ -166,7 +166,7 @@ fn get_wtn_proposal_id(nns_proposal_id: u64) -> Result<ProposalId, ProposalId> {
                 id: nns_proposal_id,
             })
             .cloned()
-            .ok_or_else(|| s.last_nns_proposal_seen.clone())
+            .ok_or_else(|| s.last_nns_proposal_processed.clone())
     })
 }
 

--- a/water_neuron/src/proposal.rs
+++ b/water_neuron/src/proposal.rs
@@ -51,12 +51,6 @@ pub async fn mirror_proposals() -> Result<(), String> {
                     }
                 };
 
-                mutate_state(|s| {
-                    if proposal_id > s.last_nns_proposal_seen {
-                        s.last_nns_proposal_seen = proposal_id.clone();
-                    }
-                });
-
                 // Skip proposal ineligible for rewards.
                 // https://github.com/dfinity/ic/blob/17df8febdb922c3981475035d830f09d9b990a5a/rs/nns/governance/src/gen/ic_nns_governance.pb.v1.rs#L4127
                 if proposal_info.reward_status > 1 {
@@ -90,7 +84,7 @@ pub async fn mirror_proposals() -> Result<(), String> {
                                                 id: sns_proposal_id.id,
                                             },
                                         },
-                                    )
+                                    );
                                 });
                                 continue;
                             }

--- a/water_neuron/src/state.rs
+++ b/water_neuron/src/state.rs
@@ -161,7 +161,7 @@ pub struct State {
     // NNS Proposal Id to SNS Proposals ID
     pub proposals: BTreeMap<ProposalId, ProposalId>,
     pub voted_proposals: BTreeSet<ProposalId>,
-    pub last_nns_proposal_seen: ProposalId,
+    pub last_nns_proposal_processed: ProposalId,
 
     // Airdrop Map
     pub airdrop: BTreeMap<Principal, WTN>,
@@ -247,7 +247,7 @@ impl State {
             principal_guards: BTreeSet::default(),
             active_tasks: BTreeSet::default(),
             latest_distribution_icp_per_vp: None,
-            last_nns_proposal_seen: Default::default(),
+            last_nns_proposal_processed: Default::default(),
             last_distribution_ts: timestamp_nanos(),
         }
     }

--- a/water_neuron/src/state/audit.rs
+++ b/water_neuron/src/state/audit.rs
@@ -105,6 +105,10 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType, timestamp:
             state
                 .proposals
                 .insert(nns_proposal_id.clone(), sns_proposal_id.clone());
+
+            if nns_proposal_id > state.last_nns_proposal_processed {
+                state.last_nns_proposal_processed = proposal_id.clone();
+            }
         }
     }
 }

--- a/water_neuron/src/state/audit.rs
+++ b/water_neuron/src/state/audit.rs
@@ -106,8 +106,8 @@ pub fn apply_state_transition(state: &mut State, payload: &EventType, timestamp:
                 .proposals
                 .insert(nns_proposal_id.clone(), sns_proposal_id.clone());
 
-            if nns_proposal_id > state.last_nns_proposal_processed {
-                state.last_nns_proposal_processed = proposal_id.clone();
+            if *nns_proposal_id > state.last_nns_proposal_processed {
+                state.last_nns_proposal_processed = nns_proposal_id.clone();
             }
         }
     }


### PR DESCRIPTION
Prior to this PR, `last_nns_proposal_seen` was being incremented before the mirrored SNS proposal was pushed.
So when calling `get_wtn_proposal_id` it would incorrectly reply with `Ok(None)` because no SNS proposal exists yet even though there will be one shortly.
With this change in place, that same call to `get_wtn_proposal_id` would return `Err(...)`, signalling that the NNS proposal hasn't been processed yet.