### PR TITLE
`ic-wasm-utils` add compilation of canisters

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,15 +4,21 @@ LMDB_H_PATH = "/usr/include/lmdb.h"
 LMDB_OVERRIDE = "/usr/lib/x86_64-linux-gnu/liblmdb.a"
 
 [alias]
-canister = "build --target wasm32-unknown-unknown" 
+canister = "build --target wasm32-unknown-unknown"
+canisters = "run -p ic_wasm_utils"
 
 [target.wasm32-unknown-unknown]
 rustflags = [
-    "-C", "link-args=-z stack-size=3145728",
-    "-C", "linker-plugin-lto",
-    "-C", "opt-level=3",
-    "-C", "debug-assertions=no",
-    "-C", "debuginfo=0",
+    "-C",
+    "link-args=-z stack-size=3145728",
+    "-C",
+    "linker-plugin-lto",
+    "-C",
+    "opt-level=3",
+    "-C",
+    "debug-assertions=no",
+    "-C",
+    "debuginfo=0",
 ]
 
 [toolchain]

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ USER ubuntu
 ENV PATH=/home/ubuntu/.cargo/bin:/home/ubuntu/.local/bin:$PATH
 
 # Add Rust/Cargo support
-ARG RUST_VERSION=1.79.0
+ARG RUST_VERSION=1.82.0
 RUN curl --fail https://sh.rustup.rs -sSf \
     | sh -s -- -y --default-toolchain ${RUST_VERSION}-x86_64-unknown-linux-gnu --no-modify-path && \
     rustup default ${RUST_VERSION}-x86_64-unknown-linux-gnu && \

--- a/ic_wasm_utils/src/lib.rs
+++ b/ic_wasm_utils/src/lib.rs
@@ -157,7 +157,7 @@ fn build_local_wasm(name: &str, self_check: bool) -> Result<PathBuf> {
         format!("ic-wasm target/wasm32-unknown-unknown/release/{0}.wasm -o artifacts/{0}_candid.wasm metadata candid:service -f {0}/{0}.did -v public", name),
         format!("ic-wasm artifacts/{0}_candid.wasm -o artifacts/{0}_candid_git.wasm metadata git_commit_id -d $(git rev-parse HEAD) -v public", name),
         format!("ic-wasm artifacts/{0}_candid_git.wasm -o artifacts/{0}_candid_git_shrink.wasm shrink", name),
-        format!("gzip -ncf9v artifacts/{0}_candid_git_shrink.wasm > artifacts/{0}.wasm.gz", name),
+        format!("gzip -c9 artifacts/{0}_candid_git_shrink.wasm > artifacts/{0}.wasm.gz", name),
     ];
 
     for cmd in &build_steps {

--- a/ic_wasm_utils/src/lib.rs
+++ b/ic_wasm_utils/src/lib.rs
@@ -22,7 +22,7 @@ pub enum Error {
 pub type Result<T> = std::result::Result<T, Error>;
 
 #[derive(Debug, Clone, Hash, Eq, PartialOrd, Ord, PartialEq)]
-pub enum CanisterName {
+pub enum CanisterName<'a> {
     Ledger,
     NnsGovernance,
     Icrc1Ledger,
@@ -32,7 +32,7 @@ pub enum CanisterName {
     SnsRoot,
     Cmc,
     Icrc1IndexNg,
-    Local(String),
+    Local(&'a str),
 }
 
 struct WasmBinary {
@@ -42,7 +42,7 @@ struct WasmBinary {
 }
 
 lazy_static! {
-    static ref DFINITY_CANISTERS: BTreeMap<CanisterName, WasmBinary> = {
+    static ref DFINITY_CANISTERS: BTreeMap<CanisterName<'static>, WasmBinary> = {
         let mut map = BTreeMap::new();
         map.insert(
             CanisterName::Ledger,
@@ -124,29 +124,40 @@ lazy_static! {
         .expect("Failed to get workspace root")
         .workspace_root
         .into();
-    static ref BOOMERANG_WASM: Vec<u8> = get_wasm(CanisterName::Local("boomerang".into())).unwrap();
+    static ref BOOMERANG_WASM: Vec<u8> =
+        get_wasm(CanisterName::Local("boomerang".into()), true).unwrap();
     static ref WATER_NEURON_WASM: Vec<u8> =
-        get_wasm(CanisterName::Local("water_neuron".into())).unwrap();
+        get_wasm(CanisterName::Local("water_neuron".into()), true).unwrap();
     static ref SNS_MODULE_WASM: Vec<u8> =
-        get_wasm(CanisterName::Local("sns_module".into())).unwrap();
+        get_wasm(CanisterName::Local("sns_module".into()), true).unwrap();
 }
 
-fn get_wasm(name: CanisterName) -> Result<Vec<u8>> {
+pub fn get_wasm_path(name: CanisterName, self_check: bool) -> Result<PathBuf> {
     match name {
-        CanisterName::Local(name) => build_local_wasm(&name),
+        CanisterName::Local(name) => build_local_wasm(&name, self_check),
         remote => fetch_remote_wasm(&remote),
     }
 }
 
-fn build_local_wasm(name: &str) -> Result<Vec<u8>> {
+fn get_wasm(name: CanisterName, self_check: bool) -> Result<Vec<u8>> {
+    Ok(std::fs::read(get_wasm_path(name, self_check)?)?)
+}
+
+fn build_local_wasm(name: &str, self_check: bool) -> Result<PathBuf> {
     std::fs::create_dir_all(WORKSPACE_ROOT.join("artifacts"))?;
 
+    let self_check_flag = if self_check {
+        "--features=self_check"
+    } else {
+        ""
+    };
+
     let build_steps = [
-        format!("cargo canister -p {0} --release --bin {0} --locked --features=self_check", name),
-        format!("ic-wasm target/wasm32-unknown-unknown/release/{0}.wasm -o artifacts/{0}_final.wasm metadata candid:service -f {0}/{0}.did -v public", name),
-        format!("ic-wasm artifacts/{0}_final.wasm metadata git_commit_id -d $(git rev-parse HEAD) -v public", name),
-        format!("ic-wasm artifacts/{0}_final.wasm shrink", name),
-        format!("gzip -nf9v artifacts/{0}_final.wasm", name),
+        format!("cargo canister -p {0} --release --bin {0} --locked {1}", name, self_check_flag),
+        format!("ic-wasm target/wasm32-unknown-unknown/release/{0}.wasm -o artifacts/{0}.wasm metadata candid:service -f {0}/{0}.did -v public", name),
+        format!("ic-wasm artifacts/{0}.wasm metadata git_commit_id -d $(git rev-parse HEAD) -v public", name),
+        format!("ic-wasm artifacts/{0}.wasm shrink", name),
+        format!("gzip -nf9v artifacts/{0}.wasm", name),
     ];
 
     for cmd in &build_steps {
@@ -160,12 +171,10 @@ fn build_local_wasm(name: &str) -> Result<Vec<u8>> {
         }
     }
 
-    Ok(std::fs::read(
-        WORKSPACE_ROOT.join(format!("artifacts/{}_final.wasm.gz", name)),
-    )?)
+    Ok(WORKSPACE_ROOT.join(format!("artifacts/{}.wasm.gz", name)))
 }
 
-fn fetch_remote_wasm(canister: &CanisterName) -> Result<Vec<u8>> {
+fn fetch_remote_wasm(canister: &CanisterName) -> Result<PathBuf> {
     let wasm = DFINITY_CANISTERS
         .get(canister)
         .ok_or(Error::UnknownCanister)?;
@@ -175,7 +184,7 @@ fn fetch_remote_wasm(canister: &CanisterName) -> Result<Vec<u8>> {
         let mut hasher = Sha256::new();
         hasher.update(&data);
         if format!("{:x}", hasher.finalize()) == wasm.hash {
-            return Ok(data);
+            return Ok(cache_path);
         }
     }
 
@@ -194,7 +203,7 @@ fn fetch_remote_wasm(canister: &CanisterName) -> Result<Vec<u8>> {
     }
 
     std::fs::write(&cache_path, &data)?;
-    Ok(data)
+    Ok(cache_path)
 }
 
 pub fn boomerang_wasm() -> Vec<u8> {
@@ -208,23 +217,23 @@ pub fn sns_module_wasm() -> Vec<u8> {
 }
 
 pub fn icp_ledger_wasm() -> Vec<u8> {
-    get_wasm(CanisterName::Ledger).unwrap()
+    get_wasm(CanisterName::Ledger, false).unwrap()
 }
 pub fn governance_wasm() -> Vec<u8> {
-    get_wasm(CanisterName::NnsGovernance).unwrap()
+    get_wasm(CanisterName::NnsGovernance, false).unwrap()
 }
 pub fn ledger_wasm() -> Vec<u8> {
-    get_wasm(CanisterName::Icrc1Ledger).unwrap()
+    get_wasm(CanisterName::Icrc1Ledger, false).unwrap()
 }
 pub fn sns_governance_wasm() -> Vec<u8> {
-    get_wasm(CanisterName::SnsGovernance).unwrap()
+    get_wasm(CanisterName::SnsGovernance, false).unwrap()
 }
 pub fn sns_root_wasm() -> Vec<u8> {
-    get_wasm(CanisterName::SnsRoot).unwrap()
+    get_wasm(CanisterName::SnsRoot, false).unwrap()
 }
 pub fn sns_swap_wasm() -> Vec<u8> {
-    get_wasm(CanisterName::SnsSwap).unwrap()
+    get_wasm(CanisterName::SnsSwap, false).unwrap()
 }
 pub fn cmc_wasm() -> Vec<u8> {
-    get_wasm(CanisterName::Cmc).unwrap()
+    get_wasm(CanisterName::Cmc, false).unwrap()
 }

--- a/ic_wasm_utils/src/lib.rs
+++ b/ic_wasm_utils/src/lib.rs
@@ -154,10 +154,10 @@ fn build_local_wasm(name: &str, self_check: bool) -> Result<PathBuf> {
 
     let build_steps = [
         format!("cargo canister -p {0} --release --bin {0} --locked {1}", name, self_check_flag),
-        format!("ic-wasm target/wasm32-unknown-unknown/release/{0}.wasm -o artifacts/{0}.wasm metadata candid:service -f {0}/{0}.did -v public", name),
-        format!("ic-wasm artifacts/{0}.wasm metadata git_commit_id -d $(git rev-parse HEAD) -v public", name),
-        format!("ic-wasm artifacts/{0}.wasm shrink", name),
-        format!("gzip -nf9v artifacts/{0}.wasm", name),
+        format!("ic-wasm target/wasm32-unknown-unknown/release/{0}.wasm -o artifacts/{0}_candid.wasm metadata candid:service -f {0}/{0}.did -v public", name),
+        format!("ic-wasm artifacts/{0}_candid.wasm -o artifacts/{0}_candid_git.wasm metadata git_commit_id -d $(git rev-parse HEAD) -v public", name),
+        format!("ic-wasm artifacts/{0}_candid_git.wasm -o artifacts/{0}_candid_git_shrink.wasm shrink", name),
+        format!("gzip -ncf9v artifacts/{0}_candid_git_shrink.wasm > artifacts/{0}.wasm.gz", name),
     ];
 
     for cmd in &build_steps {

--- a/ic_wasm_utils/src/lib.rs
+++ b/ic_wasm_utils/src/lib.rs
@@ -157,7 +157,8 @@ fn build_local_wasm(name: &str, self_check: bool) -> Result<PathBuf> {
         format!("ic-wasm target/wasm32-unknown-unknown/release/{0}.wasm -o artifacts/{0}_candid.wasm metadata candid:service -f {0}/{0}.did -v public", name),
         format!("ic-wasm artifacts/{0}_candid.wasm -o artifacts/{0}_candid_git.wasm metadata git_commit_id -d $(git rev-parse HEAD) -v public", name),
         format!("ic-wasm artifacts/{0}_candid_git.wasm -o artifacts/{0}_candid_git_shrink.wasm shrink", name),
-        format!("gzip -c9 artifacts/{0}_candid_git_shrink.wasm > artifacts/{0}.wasm.gz", name),
+        format!("gzip -nf9v artifacts/{0}_candid_git_shrink.wasm", name),
+        format!("mv artifacts/{0}_candid_git_shrink.wasm.gz artifacts/{0}.wasm.gz", name),
     ];
 
     for cmd in &build_steps {

--- a/ic_wasm_utils/src/main.rs
+++ b/ic_wasm_utils/src/main.rs
@@ -25,18 +25,20 @@ fn main() {
     let mut sums = vec![];
 
     for (name, path) in CANISTER_PATHS.iter() {
-        println!("\n{}", name);
+        println!("Building {}...", name);
         let data = std::fs::read(path).unwrap();
         let mut hasher = Sha256::new();
         hasher.update(&data);
         let sum = format!("{:x}", hasher.finalize());
-        sums.push((path, sum));
-        println!("{} canister compiled", name);
+        sums.push((name, path, sum));
     }
 
-    println!("\n=== Summary ===");
-    for (path, sum) in sums {
-        println!("{:?}: {}", path, sum);
+    println!("\nSHA256 Checksums:");
+    println!("─────────────────────────────────────────────");
+    for (name, path, sum) in sums {
+        println!("{:<12} {}", name, sum);
+        println!("           → {:?}", path);
+        println!();
     }
 
     let commit = String::from_utf8(
@@ -47,5 +49,5 @@ fn main() {
             .stdout,
     )
     .unwrap();
-    println!("\ncommit: {}", commit.trim());
+    println!("Git commit:   {}", commit.trim());
 }

--- a/ic_wasm_utils/src/main.rs
+++ b/ic_wasm_utils/src/main.rs
@@ -26,7 +26,7 @@ fn main() {
 
     for (name, path) in CANISTER_PATHS.iter() {
         println!("Building {}...", name);
-        let data = std::fs::read(path).unwrap();
+        let data = std::fs::read(path).expect(&format!("Could not read {:?}", path));
         let mut hasher = Sha256::new();
         hasher.update(&data);
         let sum = format!("{:x}", hasher.finalize());

--- a/ic_wasm_utils/src/main.rs
+++ b/ic_wasm_utils/src/main.rs
@@ -1,27 +1,51 @@
-use ic_wasm_utils::*;
+use ic_wasm_utils::{get_wasm_path, CanisterName};
+use lazy_static::lazy_static;
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use std::process::Command;
+
+lazy_static! {
+    static ref CANISTER_PATHS: Vec<(String, PathBuf)> = vec![
+        (
+            "boomerang".into(),
+            get_wasm_path(CanisterName::Local("boomerang".into()), false).unwrap()
+        ),
+        (
+            "water_neuron".into(),
+            get_wasm_path(CanisterName::Local("water_neuron".into()), false).unwrap()
+        ),
+        (
+            "sns_module".into(),
+            get_wasm_path(CanisterName::Local("sns_module".into()), false).unwrap()
+        ),
+    ];
+}
 
 fn main() {
-    println!("Testing boomerang...");
-    println!("Size: {} bytes", boomerang_wasm().len());
+    let mut sums = vec![];
 
-    println!("\nTesting water_neuron...");
-    println!("Size: {} bytes", water_neuron_wasm().len());
+    for (name, path) in CANISTER_PATHS.iter() {
+        println!("\n{}", name);
+        let data = std::fs::read(path).unwrap();
+        let mut hasher = Sha256::new();
+        hasher.update(&data);
+        let sum = format!("{:x}", hasher.finalize());
+        sums.push((path, sum));
+        println!("{} canister compiled", name);
+    }
 
-    println!("\nTesting icp_ledger...");
-    println!("Size: {} bytes", icp_ledger_wasm().len());
+    println!("\n=== Summary ===");
+    for (path, sum) in sums {
+        println!("{:?}: {}", path, sum);
+    }
 
-    println!("\nTesting governance...");
-    println!("Size: {} bytes", governance_wasm().len());
-
-    println!("\nTesting ledger...");
-    println!("Size: {} bytes", ledger_wasm().len());
-
-    println!("\nTesting sns_governance...");
-    println!("Size: {} bytes", sns_governance_wasm().len());
-
-    println!("\nTesting sns_root...");
-    println!("Size: {} bytes", sns_root_wasm().len());
-
-    println!("\nTesting sns_swap...");
-    println!("Size: {} bytes", sns_swap_wasm().len());
+    let commit = String::from_utf8(
+        Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap();
+    println!("\ncommit: {}", commit.trim());
 }

--- a/run.sh
+++ b/run.sh
@@ -33,7 +33,7 @@ if [[ "$MODE" == "build" ]]; then
     PODMAN_ARGS+=(
         /usr/bin/bash
         -c
-        "cargo canister --release -p water_neuron -p boomerang -p sns_module --bin water_neuron --bin boomerang --bin sns_module"
+        "cargo canisters"
     )
 fi
 


### PR DESCRIPTION
we can compile all the local canisters with `cargo canisters`
```
Building boomerang...
Building water_neuron...
Building sns_module...

SHA256 Checksums:
─────────────────────────────────────────────
boomerang    5fd5c191caf0afbc48209c65ecb59bc39bd13d4f349dcac2800433e784f4c862
           → "/home/enzo/code/WaterNeuron/artifacts/boomerang.wasm.gz"

water_neuron 839ebcd61af8f385cb95f18467a78d9e783528c2b1c19eb256b1e073d37b30d2
           → "/home/enzo/code/WaterNeuron/artifacts/water_neuron.wasm.gz"

sns_module   df9d095f8b72661a9635093591648235a4e5df0c42a8e5fc8adcdefda48397fb
           → "/home/enzo/code/WaterNeuron/artifacts/sns_module.wasm.gz"

Git commit:   53a9e2e2315e62a9e6600f1951db6c35fe858470
```