### PR TITLE
Support Recovery of Uncommitted ICP (SNS Module)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ We recommend the Determinate Systems nix install tool which you can find [here](
 You need the following packages to run system tests.
 
 ```bash
-sudo apt udpate && sudo apt install \
+sudo apt update && sudo apt install \
         curl \
         git \
         gcc \

--- a/sns_module/sns_module.did
+++ b/sns_module/sns_module.did
@@ -35,6 +35,7 @@ service : (InitArg) -> {
   get_status : () -> (Status) query;
   get_wtn_allocated : (principal) -> (nat64) query;
   notify_icp_deposit : (principal, nat64) -> (Result);
+  return_uncommited_icp : (principal, nat64) -> (Result);
   set_is_wtn_claimable : (bool) -> (variant { Ok; Err : text });
   stake_icp : (nat64) -> (Result);
 }

--- a/sns_module/sns_module.did
+++ b/sns_module/sns_module.did
@@ -35,7 +35,7 @@ service : (InitArg) -> {
   get_status : () -> (Status) query;
   get_wtn_allocated : (principal) -> (nat64) query;
   notify_icp_deposit : (principal, nat64) -> (Result);
-  return_uncommited_icp : (principal, nat64) -> (Result);
+  return_uncommitted_icp : (principal, nat64) -> (Result);
   set_is_wtn_claimable : (bool) -> (variant { Ok; Err : text });
   stake_icp : (nat64) -> (Result);
 }

--- a/sns_module/src/main.rs
+++ b/sns_module/src/main.rs
@@ -195,6 +195,26 @@ fn check_target() {
     assert_eq!(format!("{}", eight_years_account()), "rrkah-fqaaa-aaaaa-aaaaq-cai-k5odt6i.cc3beb0e3a6d7e26485fde67916225d1c2fcb7398590a92bffb97c8704140b25".to_string());
 }
 
+// Returns the uncommited ICP back to the target Principal.
+// Recommended to use `get_icp_deposit_address` to check the correct amount before calling this function.
+#[update]
+async fn return_uncommited_icp(target: Principal, amount: u64) -> Result<u64, String> {
+    let icp_ledger = read_state(|s| s.icp_ledger_id);
+    let tokens = amount.checked_sub(10_000).unwrap();
+    match transfer(
+        Some(derive_staking(target)),
+        target,
+        Nat::from(tokens),
+        None,
+        icp_ledger,
+    )
+    .await
+    {
+        Ok(block_index) => Ok(block_index),
+        Err(e) => Err(format!("{e}")),
+    }
+}
+
 #[update]
 async fn claim_wtn(of: Principal) -> Result<u64, String> {
     let wtn_amount = sns_module::memory::get_wtn_owed(of);

--- a/sns_module/src/main.rs
+++ b/sns_module/src/main.rs
@@ -195,10 +195,10 @@ fn check_target() {
     assert_eq!(format!("{}", eight_years_account()), "rrkah-fqaaa-aaaaa-aaaaq-cai-k5odt6i.cc3beb0e3a6d7e26485fde67916225d1c2fcb7398590a92bffb97c8704140b25".to_string());
 }
 
-// Returns the uncommited ICP back to the target Principal.
+// Returns the uncommitted ICP back to the target Principal.
 // Recommended to use `get_icp_deposit_address` to check the correct amount before calling this function.
 #[update]
-async fn return_uncommited_icp(target: Principal, amount: u64) -> Result<u64, String> {
+async fn return_uncommitted_icp(target: Principal, amount: u64) -> Result<u64, String> {
     let icp_ledger = read_state(|s| s.icp_ledger_id);
     let tokens = amount.checked_sub(10_000).unwrap();
     match transfer(

--- a/sns_module/src/state_machine.rs
+++ b/sns_module/src/state_machine.rs
@@ -1,5 +1,5 @@
 use crate::state::InitArg as SnsModuleInitArg;
-use crate::{DEV_WALLET, E8S};
+use crate::{derive_staking, DEV_WALLET, E8S};
 use assert_matches::assert_matches;
 use candid::{Decode, Encode, Nat, Principal};
 use ic_base_types::{CanisterId, PrincipalId};
@@ -242,6 +242,23 @@ impl SnsModuleEnv {
         .unwrap()
     }
 
+    fn return_uncommited_icp(&self, target: Principal, amount: u64) -> Result<u64, String> {
+        Decode!(
+            &assert_reply(
+                self.env
+                    .execute_ingress_as(
+                        PrincipalId::new_user_test_id(0),
+                        self.sns_module_id,
+                        "return_uncommited_icp",
+                        Encode!(&target, &amount).unwrap()
+                    )
+                    .unwrap()
+            ),
+            Result<u64, String>
+        )
+        .unwrap()
+    }
+
     fn claim_wtn(&self, target: Principal) -> Result<u64, String> {
         Decode!(
             &assert_reply(
@@ -363,6 +380,26 @@ fn e2e_basic() {
     assert_eq!(env.get_wtn_allocated(nns_principal), 0);
 
     assert!(env.notify_icp_deposit(nns_principal, 10_000 * E8S).is_err());
+}
+
+#[test]
+fn should_return_uncommited_icp() {
+    let env = SnsModuleEnv::new();
+
+    let nns_principal =
+        Principal::from_text("wwyv5-q3sgh-tae7o-v2wq7-zd32d-mv4xa-xuaup-z3r5z-vmfcg-xsm6p-xqe")
+            .unwrap();
+    let deposit_address = env.get_icp_deposit_address(nns_principal);
+    let deposit_account = Account{ owner: env.sns_module_id.into(), subaccount: Some(derive_staking(nns_principal))};
+
+    let amount = 10_000 * E8S;
+
+    assert_eq!(env.icp_transfer(env.user, deposit_address, amount), 2);
+    assert_eq!(env.balance_of(env.icp_ledger_id, deposit_account), amount);
+
+    assert_eq!(env.return_uncommited_icp(nns_principal, amount), Ok(3));
+    assert_eq!(env.balance_of(env.icp_ledger_id, nns_principal), amount - 10_000);
+    assert_eq!(env.balance_of(env.icp_ledger_id, deposit_account), 0u64);
 }
 
 #[test]

--- a/sns_module/src/state_machine.rs
+++ b/sns_module/src/state_machine.rs
@@ -242,14 +242,14 @@ impl SnsModuleEnv {
         .unwrap()
     }
 
-    fn return_uncommited_icp(&self, target: Principal, amount: u64) -> Result<u64, String> {
+    fn return_uncommitted_icp(&self, target: Principal, amount: u64) -> Result<u64, String> {
         Decode!(
             &assert_reply(
                 self.env
                     .execute_ingress_as(
                         PrincipalId::new_user_test_id(0),
                         self.sns_module_id,
-                        "return_uncommited_icp",
+                        "return_uncommitted_icp",
                         Encode!(&target, &amount).unwrap()
                     )
                     .unwrap()
@@ -383,7 +383,7 @@ fn e2e_basic() {
 }
 
 #[test]
-fn should_return_uncommited_icp() {
+fn should_return_uncommitted_icp() {
     let env = SnsModuleEnv::new();
 
     let nns_principal =
@@ -400,7 +400,7 @@ fn should_return_uncommited_icp() {
     assert_eq!(env.icp_transfer(env.user, deposit_address, amount), 2);
     assert_eq!(env.balance_of(env.icp_ledger_id, deposit_account), amount);
 
-    assert_eq!(env.return_uncommited_icp(nns_principal, amount), Ok(3));
+    assert_eq!(env.return_uncommitted_icp(nns_principal, amount), Ok(3));
     assert_eq!(
         env.balance_of(env.icp_ledger_id, nns_principal),
         amount - 10_000

--- a/sns_module/src/state_machine.rs
+++ b/sns_module/src/state_machine.rs
@@ -390,7 +390,10 @@ fn should_return_uncommited_icp() {
         Principal::from_text("wwyv5-q3sgh-tae7o-v2wq7-zd32d-mv4xa-xuaup-z3r5z-vmfcg-xsm6p-xqe")
             .unwrap();
     let deposit_address = env.get_icp_deposit_address(nns_principal);
-    let deposit_account = Account{ owner: env.sns_module_id.into(), subaccount: Some(derive_staking(nns_principal))};
+    let deposit_account = Account {
+        owner: env.sns_module_id.into(),
+        subaccount: Some(derive_staking(nns_principal)),
+    };
 
     let amount = 10_000 * E8S;
 
@@ -398,7 +401,10 @@ fn should_return_uncommited_icp() {
     assert_eq!(env.balance_of(env.icp_ledger_id, deposit_account), amount);
 
     assert_eq!(env.return_uncommited_icp(nns_principal, amount), Ok(3));
-    assert_eq!(env.balance_of(env.icp_ledger_id, nns_principal), amount - 10_000);
+    assert_eq!(
+        env.balance_of(env.icp_ledger_id, nns_principal),
+        amount - 10_000
+    );
     assert_eq!(env.balance_of(env.icp_ledger_id, deposit_account), 0u64);
 }
 


### PR DESCRIPTION
Some users send ICP to their SNS swap account, but forgot/did not manage to commit this to the swap. This PR adds an endpoint to send back the funds to the principal they entered the swap with (i.e. the principal used to generate the derived accounts).