### PR TITLE
feat: add SNS endpoint to set neuron visibility

### DIFF
--- a/water_neuron/src/lib.rs
+++ b/water_neuron/src/lib.rs
@@ -2,9 +2,9 @@ use crate::dashboard::DisplayAmount;
 use crate::guards::{GuardError, TaskGuard};
 use crate::logs::{DEBUG, INFO};
 use crate::management::{
-    balance_of, disburse, follow_neuron, get_full_neuron,
-    increase_dissolve_delay, list_neurons, manage_neuron_sns, refresh_neuron, register_vote,
-    spawn_all_maturity, split_neuron, start_dissolving, transfer,
+    balance_of, disburse, follow_neuron, get_full_neuron, increase_dissolve_delay, list_neurons,
+    manage_neuron_sns, refresh_neuron, register_vote, spawn_all_maturity, split_neuron,
+    start_dissolving, transfer,
 };
 use crate::nns_types::{NeuronId, ProposalId, is_dissolved};
 use crate::numeric::{ICP, nICP};
@@ -417,13 +417,21 @@ pub fn timer() {
                         Err(_) => return,
                     };
 
-                    if is_canister_stopping() { return; }
+                    if is_canister_stopping() {
+                        return;
+                    }
                     refresh_stakes().await;
-                    if is_canister_stopping() { return; }
+                    if is_canister_stopping() {
+                        return;
+                    }
                     process_witdhrawals_splitting().await;
-                    if is_canister_stopping() { return; }
+                    if is_canister_stopping() {
+                        return;
+                    }
                     process_start_dissolving().await;
-                    if is_canister_stopping() { return; }
+                    if is_canister_stopping() {
+                        return;
+                    }
                     process_disburse().await;
 
                     schedule_after(LOGIC_DELAY, TaskType::ProcessLogic);
@@ -449,8 +457,7 @@ pub fn timer() {
 
                     let _ = refresh_neuron(SIX_MONTHS_NEURON_NONCE).await;
                     if let Some(neuron_id_6m) = read_state(|s| s.neuron_id_6m) {
-                        if let Ok(main_neuron_6m_staked) =
-                            fetch_neuron_stake(neuron_id_6m.id).await
+                        if let Ok(main_neuron_6m_staked) = fetch_neuron_stake(neuron_id_6m.id).await
                         {
                             mutate_state(|s| s.main_neuron_6m_staked = main_neuron_6m_staked);
                         }
@@ -605,7 +612,10 @@ async fn process_pending_transfer() -> u64 {
 
     for transfer in pending_transfers {
         if is_canister_stopping() {
-            log!(INFO, "[process_pending_transfer] Canister is stopping, aborting.");
+            log!(
+                INFO,
+                "[process_pending_transfer] Canister is stopping, aborting."
+            );
             return error_count;
         }
         let (ledger_id, fee) = (transfer.unit.ledger_id(), transfer.unit.fee());
@@ -776,7 +786,10 @@ pub async fn process_start_dissolving() {
 
     for neuron_id in &dissolve_request_ids {
         if is_canister_stopping() {
-            log!(INFO, "[process_start_dissolving] Canister is stopping, aborting.");
+            log!(
+                INFO,
+                "[process_start_dissolving] Canister is stopping, aborting."
+            );
             return;
         }
         let result = start_dissolving(*neuron_id).await;
@@ -1102,7 +1115,10 @@ pub async fn process_witdhrawals_splitting() {
 
     for withdrawal_id in requests_ids {
         if is_canister_stopping() {
-            log!(INFO, "[process_witdhrawals_splitting] Canister is stopping, aborting.");
+            log!(
+                INFO,
+                "[process_witdhrawals_splitting] Canister is stopping, aborting."
+            );
             return;
         }
         let request = read_state(|s| {

--- a/water_neuron/src/main.rs
+++ b/water_neuron/src/main.rs
@@ -260,7 +260,10 @@ async fn debug_disburse_status() -> Result<String, String> {
     let to_disburse = read_state(|s| s.to_disburse.clone());
     out.push_str(&format!("to_disburse has {} entries:\n", to_disburse.len()));
     for (nid, req) in &to_disburse {
-        out.push_str(&format!("  neuron {} -> receiver {:?}\n", nid.id, req.receiver));
+        out.push_str(&format!(
+            "  neuron {} -> receiver {:?}\n",
+            nid.id, req.receiver
+        ));
     }
     out.push('\n');
 
@@ -318,7 +321,10 @@ async fn debug_disburse_status() -> Result<String, String> {
 }
 
 #[update(hidden = true)]
-async fn set_neuron_visibility(neuron_nonce: u64, visibility: i32) -> Result<ManageNeuronResponse, String> {
+async fn set_neuron_visibility(
+    neuron_nonce: u64,
+    visibility: i32,
+) -> Result<ManageNeuronResponse, String> {
     assert_eq!(
         ic_cdk::api::msg_caller(),
         read_state(|s| s.wtn_governance_id)
@@ -328,13 +334,18 @@ async fn set_neuron_visibility(neuron_nonce: u64, visibility: i32) -> Result<Man
 }
 
 #[update(hidden = true)]
-async fn set_neuron_visibility_validate(neuron_nonce: u64, visibility: i32) -> Result<String, String> {
+async fn set_neuron_visibility_validate(
+    neuron_nonce: u64,
+    visibility: i32,
+) -> Result<String, String> {
     assert_eq!(
         ic_cdk::api::msg_caller(),
         read_state(|s| s.wtn_governance_id)
     );
 
-    Ok(format!("Set neuron (nonce {neuron_nonce}) visibility to {visibility}"))
+    Ok(format!(
+        "Set neuron (nonce {neuron_nonce}) visibility to {visibility}"
+    ))
 }
 
 #[update(hidden = true)]

--- a/water_neuron/src/main.rs
+++ b/water_neuron/src/main.rs
@@ -318,6 +318,26 @@ async fn debug_disburse_status() -> Result<String, String> {
 }
 
 #[update(hidden = true)]
+async fn set_neuron_visibility(neuron_nonce: u64, visibility: i32) -> Result<ManageNeuronResponse, String> {
+    assert_eq!(
+        ic_cdk::api::msg_caller(),
+        read_state(|s| s.wtn_governance_id)
+    );
+
+    water_neuron::management::set_neuron_visibility(neuron_nonce, visibility).await
+}
+
+#[update(hidden = true)]
+async fn set_neuron_visibility_validate(neuron_nonce: u64, visibility: i32) -> Result<String, String> {
+    assert_eq!(
+        ic_cdk::api::msg_caller(),
+        read_state(|s| s.wtn_governance_id)
+    );
+
+    Ok(format!("Set neuron (nonce {neuron_nonce}) visibility to {visibility}"))
+}
+
+#[update(hidden = true)]
 async fn approve_proposal(id: u64) -> Result<ManageNeuronResponse, String> {
     assert_eq!(
         ic_cdk::api::msg_caller(),

--- a/water_neuron/src/management.rs
+++ b/water_neuron/src/management.rs
@@ -7,8 +7,8 @@ use ic_nns_governance_api::{
     ListProposalInfoResponse, ManageNeuronProposal, ManageNeuronResponse, Neuron, Topic,
     manage_neuron::{
         ClaimOrRefresh, Configure, Disburse, Follow, IncreaseDissolveDelay,
-        ManageNeuronProposalCommand, Merge, NeuronIdOrSubaccount, RegisterVote, Spawn, Split,
-        StartDissolving, StopDissolving,
+        ManageNeuronProposalCommand, Merge, NeuronIdOrSubaccount, RegisterVote, SetVisibility,
+        Spawn, Split, StartDissolving, StopDissolving,
         claim_or_refresh::{By, MemoAndController},
         configure::Operation,
     },
@@ -241,6 +241,21 @@ pub async fn increase_dissolve_delay(
         ManageNeuronProposalCommand::Configure(Configure {
             operation: Some(Operation::IncreaseDissolveDelay(IncreaseDissolveDelay {
                 additional_dissolve_delay_seconds,
+            })),
+        }),
+        NeuronNonceOrId::Nonce(neuron_nonce),
+    )
+    .await
+}
+
+pub async fn set_neuron_visibility(
+    neuron_nonce: u64,
+    visibility: i32,
+) -> Result<ManageNeuronResponse, String> {
+    manage_neuron(
+        ManageNeuronProposalCommand::Configure(Configure {
+            operation: Some(Operation::SetVisibility(SetVisibility {
+                visibility: Some(visibility),
             })),
         }),
         NeuronNonceOrId::Nonce(neuron_nonce),

--- a/water_neuron/src/proposal.rs
+++ b/water_neuron/src/proposal.rs
@@ -147,7 +147,10 @@ pub async fn vote_on_nns_proposals() {
             });
             for proposal in pending_proposals.proposal_info {
                 if is_canister_stopping() {
-                    log!(INFO, "[vote_on_nns_proposals] Canister is stopping, aborting.");
+                    log!(
+                        INFO,
+                        "[vote_on_nns_proposals] Canister is stopping, aborting."
+                    );
                     return;
                 }
                 let deadline_timestamp_seconds = proposal.deadline_timestamp_seconds.unwrap_or(0);
@@ -250,7 +253,10 @@ pub async fn early_voting_on_nns_proposals() {
 
     for proposal_id in not_voted {
         if is_canister_stopping() {
-            log!(INFO, "[early_voting_on_nns_proposals] Canister is stopping, aborting.");
+            log!(
+                INFO,
+                "[early_voting_on_nns_proposals] Canister is stopping, aborting."
+            );
             return;
         }
         match get_sns_proposal(wtn_governance_id, proposal_id.id).await {


### PR DESCRIPTION
The 6-month neuron is currently private. To make it public, we need to call SetVisibility via NNS governance. Since the protocol is already live, this adds an SNS-governed endpoint that can be invoked via a generic nervous system function proposal.

After deploying, register the generic nervous system function and submit a proposal with args (0, 2) to set the 6m neuron to public.

## Summary

- Add `set_neuron_visibility` SNS-governed endpoint to configure NNS neuron visibility (private/public)
- Add `set_neuron_visibility_validate` counterpart required for generic nervous system function registration
- Add `set_neuron_visibility` helper in `management.rs` using the `SetVisibility` configure operation

## Next steps

After deploying:
1. Register a new generic nervous system function in SNS governance pointing to `set_neuron_visibility`
2. Submit an SNS proposal calling it with args `(0, 2)` (nonce `0` = 6m neuron, `2` = `Visibility::Public`)