### PR TITLE
log claim_or_refresh failures for main staking neurons

### DIFF
--- a/water_neuron/src/lib.rs
+++ b/water_neuron/src/lib.rs
@@ -456,7 +456,14 @@ pub fn timer() {
                         Err(_) => return,
                     };
 
-                    let _ = refresh_neuron(SIX_MONTHS_NEURON_NONCE).await;
+                    if let Err(err) = refresh_neuron(SIX_MONTHS_NEURON_NONCE).await {
+                        log!(
+                            INFO,
+                            "[RefreshShortTerm] claim_or_refresh failed for main 6-month neuron (nonce {}): {}",
+                            SIX_MONTHS_NEURON_NONCE,
+                            err,
+                        );
+                    }
                     if let Some(neuron_id_6m) = read_state(|s| s.neuron_id_6m)
                         && let Ok(main_neuron_6m_staked) = fetch_neuron_stake(neuron_id_6m.id).await
                     {
@@ -514,13 +521,27 @@ pub fn timer() {
 }
 
 pub async fn refresh_stakes() {
-    let _ = refresh_neuron(EIGHT_YEARS_NEURON_NONCE).await;
+    if let Err(err) = refresh_neuron(EIGHT_YEARS_NEURON_NONCE).await {
+        log!(
+            INFO,
+            "[refresh_stakes] claim_or_refresh failed for main 8-year neuron (nonce {}): {}",
+            EIGHT_YEARS_NEURON_NONCE,
+            err,
+        );
+    }
     if let Some(neuron_id_8y) = read_state(|s| s.neuron_id_8y)
         && let Ok(neuron_8y_stake_e8s) = fetch_neuron_stake(neuron_id_8y.id).await
     {
         mutate_state(|s| s.main_neuron_8y_stake = neuron_8y_stake_e8s);
     }
-    let _ = refresh_neuron(SIX_MONTHS_NEURON_NONCE).await;
+    if let Err(err) = refresh_neuron(SIX_MONTHS_NEURON_NONCE).await {
+        log!(
+            INFO,
+            "[refresh_stakes] claim_or_refresh failed for main 6-month neuron (nonce {}): {}",
+            SIX_MONTHS_NEURON_NONCE,
+            err,
+        );
+    }
     if let Some(neuron_id_6m) = read_state(|s| s.neuron_id_6m)
         && let Ok(main_neuron_6m_staked) = fetch_neuron_stake(neuron_id_6m.id).await
     {


### PR DESCRIPTION
hey folks, bumped into something while reading the cron-style paths.

code was calling refresh_neuron (NNS claim_or_refresh) for the two main staking neurons plus the refresh short-term task, but every failure was discarded with let _ = .... So Governance could reject or the call could fail transiently and the canister kept going with silently stale neuron state.

now each path logs at INFO with the nonce and error string when claim_or_refresh returns Err, same pattern you already use for ProcessRewardsTransfer when transfers fail.

no behavior change besides visibility; cheers